### PR TITLE
Replace placeholder tests with basic LSP behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  test:
+    name: test (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Compile Python files
+        run: python -m py_compile src/qe_lsp/server.py tests/test_basic.py
+
+      - name: Run tests
+        run: python -m pytest -q
+
+  quality:
+    name: quality
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Check formatting
+        run: black --check src tests
+
+      - name: Lint
+        run: ruff check .
+
+      - name: Type check
+        run: mypy src tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,6 @@ build-backend = "hatchling.build"
 
 [project.scripts]
 qe-lsp = "qe_lsp.server:main"
+
+[tool.black]
+target-version = ["py39"]

--- a/src/qe_lsp/__init__.py
+++ b/src/qe_lsp/__init__.py
@@ -1,2 +1,3 @@
 """qe-lsp - Language Server Protocol for qe"""
+
 __version__ = "0.1.0"

--- a/src/qe_lsp/server.py
+++ b/src/qe_lsp/server.py
@@ -1,11 +1,17 @@
-"""
-qe Language Server Protocol implementation
-"""
+"""qe Language Server Protocol implementation."""
 
-try:
-    from pygls.lsp.server import LanguageServer
-except ImportError:
-    from pygls.server import LanguageServer
+from importlib import import_module
+from typing import Any
+
+
+def _load_language_server() -> Any:
+    try:
+        return import_module("pygls.lsp.server").LanguageServer
+    except ImportError:
+        return import_module("pygls.server").LanguageServer
+
+
+LanguageServer = _load_language_server()
 
 QE_KEYWORDS = [
     "&CONTROL",
@@ -27,6 +33,47 @@ QE_HOVER_DOCS = {
 
 server = LanguageServer("qe-lsp", "0.1.0")
 
+
+def _get_attr(params, name, default=None):
+    if params is None:
+        return default
+    if isinstance(params, dict):
+        return params.get(name, default)
+    return getattr(params, name, default)
+
+
+def _get_position(params):
+    position = _get_attr(params, "position", {})
+    if isinstance(position, dict):
+        return position.get("line", 0), position.get("character", 0)
+    return _get_attr(position, "line", 0), _get_attr(position, "character", 0)
+
+
+def _get_text(params):
+    text = _get_attr(params, "text")
+    if text is not None:
+        return text
+
+    text_document = _get_attr(params, "text_document")
+    return _get_attr(text_document, "text")
+
+
+def _word_at_position(text, line_number, character):
+    lines = text.splitlines()
+    if line_number < 0 or line_number >= len(lines):
+        return ""
+
+    line = lines[line_number]
+    character = max(0, min(character, len(line)))
+    start = character
+    while start > 0 and not line[start - 1].isspace():
+        start -= 1
+    end = character
+    while end < len(line) and not line[end].isspace():
+        end += 1
+    return line[start:end].strip(",")
+
+
 @server.feature("textDocument/completion")
 def completion(params):
     return [
@@ -38,9 +85,18 @@ def completion(params):
         for keyword in QE_KEYWORDS
     ]
 
+
 @server.feature("textDocument/hover")
 def hover(params):
-    keyword = next(iter(QE_HOVER_DOCS))
+    text = _get_text(params)
+    if not text:
+        return None
+
+    line_number, character = _get_position(params)
+    keyword = _word_at_position(text, line_number, character).upper()
+    if keyword not in QE_HOVER_DOCS:
+        return None
+
     return {
         "contents": {
             "kind": "markdown",
@@ -48,12 +104,46 @@ def hover(params):
         }
     }
 
+
 @server.feature("textDocument/diagnostic")
 def diagnostic(params):
-    return []
+    text = _get_text(params)
+    if not text:
+        return []
+
+    diagnostics = []
+    open_namelist = None
+    open_line = 0
+    for line_number, raw_line in enumerate(text.splitlines()):
+        line = raw_line.strip()
+        if not line or line.startswith("!"):
+            continue
+        if line.startswith("&"):
+            open_namelist = line.split()[0].upper()
+            open_line = line_number
+            continue
+        if line == "/" and open_namelist is not None:
+            open_namelist = None
+
+    if open_namelist is not None:
+        diagnostics.append(
+            {
+                "range": {
+                    "start": {"line": open_line, "character": 0},
+                    "end": {"line": open_line, "character": len(open_namelist)},
+                },
+                "severity": 1,
+                "message": f"Unclosed namelist {open_namelist}; expected '/'.",
+                "source": "qe-lsp",
+            }
+        )
+
+    return diagnostics
+
 
 def main():
     server.start_io()
+
 
 if __name__ == "__main__":
     main()

--- a/src/qe_lsp/server.py
+++ b/src/qe_lsp/server.py
@@ -2,18 +2,51 @@
 qe Language Server Protocol implementation
 """
 
-import asyncio
-from pygls.server import LanguageServer
+try:
+    from pygls.lsp.server import LanguageServer
+except ImportError:
+    from pygls.server import LanguageServer
+
+QE_KEYWORDS = [
+    "&CONTROL",
+    "&SYSTEM",
+    "&ELECTRONS",
+    "&IONS",
+    "&CELL",
+    "ATOMIC_SPECIES",
+    "ATOMIC_POSITIONS",
+    "K_POINTS",
+    "CELL_PARAMETERS",
+]
+
+QE_HOVER_DOCS = {
+    "&CONTROL": "Calculation control namelist for Quantum ESPRESSO inputs.",
+    "&SYSTEM": "System definition namelist, including cell, atoms, cutoffs, and occupations.",
+    "&ELECTRONS": "Electronic minimization namelist for convergence and mixing settings.",
+}
 
 server = LanguageServer("qe-lsp", "0.1.0")
 
 @server.feature("textDocument/completion")
 def completion(params):
-    return []
+    return [
+        {
+            "label": keyword,
+            "kind": 14,
+            "detail": "Quantum ESPRESSO input keyword",
+        }
+        for keyword in QE_KEYWORDS
+    ]
 
 @server.feature("textDocument/hover")
 def hover(params):
-    return None
+    keyword = next(iter(QE_HOVER_DOCS))
+    return {
+        "contents": {
+            "kind": "markdown",
+            "value": f"**{keyword}**\n\n{QE_HOVER_DOCS[keyword]}",
+        }
+    }
 
 @server.feature("textDocument/diagnostic")
 def diagnostic(params):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,9 +1,13 @@
-"""
-Basic tests for qe-lsp.
-"""
+"""Basic tests for qe-lsp."""
 
 from qe_lsp import __version__
-from qe_lsp.server import QE_KEYWORDS, completion, diagnostic, hover
+from qe_lsp.server import QE_KEYWORDS, completion, diagnostic, hover, server
+
+
+class Params:
+    def __init__(self, text, line=0, character=0):
+        self.text = text
+        self.position = {"line": line, "character": character}
 
 
 def test_import():
@@ -18,18 +22,44 @@ def test_completion_returns_qe_keywords():
     labels = {item["label"] for item in items}
     assert set(QE_KEYWORDS).issubset(labels)
     assert "&CONTROL" in labels
+    assert "&SYSTEM" in labels
     assert "ATOMIC_POSITIONS" in labels
+    assert "K_POINTS" in labels
+    assert all({"label", "kind", "detail"}.issubset(item) for item in items)
 
 
-def test_hover_returns_markdown_documentation():
-    """Hover should return a markdown payload for known QE content."""
-    result = hover(None)
+def test_hover_returns_markdown_documentation_for_position():
+    """Hover should return documentation for the symbol under the cursor."""
+    result = hover(Params("&SYSTEM\n/", character=3))
 
     assert result["contents"]["kind"] == "markdown"
-    assert "&CONTROL" in result["contents"]["value"]
-    assert "Quantum ESPRESSO" in result["contents"]["value"]
+    assert "&SYSTEM" in result["contents"]["value"]
+    assert "System definition" in result["contents"]["value"]
 
 
-def test_diagnostic_is_currently_empty():
-    """Diagnostic handler currently returns an empty list."""
-    assert diagnostic(None) == []
+def test_hover_returns_none_for_unknown_content():
+    """Hover should not show misleading documentation for unknown content."""
+    assert hover(Params("unknown_keyword", character=4)) is None
+
+
+def test_diagnostic_returns_empty_for_valid_input():
+    """A minimal closed namelist should not produce diagnostics."""
+    assert diagnostic(Params("&CONTROL\n/\n")) == []
+
+
+def test_diagnostic_reports_unclosed_namelist():
+    """An unclosed namelist should produce a diagnostic."""
+    diagnostics = diagnostic(Params("&CONTROL\ncalculation = 'scf'\n"))
+
+    assert len(diagnostics) == 1
+    assert "Unclosed namelist" in diagnostics[0]["message"]
+    assert diagnostics[0]["range"]["start"]["line"] == 0
+
+
+def test_server_registers_lsp_features():
+    """Handlers should be registered with pygls, not only callable directly."""
+    features = server.protocol.fm.features
+
+    assert "textDocument/completion" in features
+    assert "textDocument/hover" in features
+    assert "textDocument/diagnostic" in features

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,15 +1,35 @@
-\"\"\"
-Basic tests for qe-lsp
-\"\"\"
+"""
+Basic tests for qe-lsp.
+"""
 
-import pytest
+from qe_lsp import __version__
+from qe_lsp.server import QE_KEYWORDS, completion, diagnostic, hover
 
 
 def test_import():
-    \"\"\"Test that the package can be imported\"\"\"
-    assert True
+    """Test that the package exposes its version."""
+    assert __version__ == "0.1.0"
 
 
-def test_placeholder():
-    \"\"\"Placeholder test - replace with actual tests\"\"\"
-    assert True
+def test_completion_returns_qe_keywords():
+    """Completion should expose common Quantum ESPRESSO input sections."""
+    items = completion(None)
+
+    labels = {item["label"] for item in items}
+    assert set(QE_KEYWORDS).issubset(labels)
+    assert "&CONTROL" in labels
+    assert "ATOMIC_POSITIONS" in labels
+
+
+def test_hover_returns_markdown_documentation():
+    """Hover should return a markdown payload for known QE content."""
+    result = hover(None)
+
+    assert result["contents"]["kind"] == "markdown"
+    assert "&CONTROL" in result["contents"]["value"]
+    assert "Quantum ESPRESSO" in result["contents"]["value"]
+
+
+def test_diagnostic_is_currently_empty():
+    """Diagnostic handler currently returns an empty list."""
+    assert diagnostic(None) == []


### PR DESCRIPTION
## Summary
- fix the invalid Python syntax in the basic test file
- add basic assertions for import, completion, hover, and diagnostic handlers
- return common Quantum ESPRESSO completion items and markdown hover content
- support both pygls 1.x and 2.x LanguageServer import paths

## Verification
- python3 -m py_compile src/qe_lsp/server.py tests/test_basic.py
- .venv/bin/pytest -q