### PR TITLE
Improve LSP responses and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,5 +62,8 @@ jobs:
       - name: Type check
         run: mypy src tests
 
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+
       - name: Build package
         run: python -m build --sdist --wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
+          python -m pip install -e ".[dev]" build
 
       - name: Check formatting
         run: black --check src tests
@@ -61,3 +61,6 @@ jobs:
 
       - name: Type check
         run: mypy src tests
+
+      - name: Build package
+        run: python -m build --sdist --wheel

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 __pycache__/
 *.py[cod]
 *.egg-info/
+.venv/
+dist/
 .pytest_cache/
 .coverage
 *.vsix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+default_stages: [pre-commit, pre-push]
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.11.0
+    hooks:
+      - id: black
+        args: ["--check", "src", "tests"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.0
+    hooks:
+      - id: ruff-check
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - lsprotocol>=2023.0.0
+          - pygls>=1.2.0
+        args: ["src", "tests"]
+        pass_filenames: false

--- a/PLAN.md
+++ b/PLAN.md
@@ -3,24 +3,24 @@
 ## Overview
 This is the development plan for qe-lsp.
 
-## Phase 1: Foundation (Week 1)
-- [ ] Setup project structure
-- [ ] Basic parser implementation
-- [ ] Initial test suite
+## Current MVP
+- [x] Setup project structure
+- [x] Basic parser implementation
+- [x] Initial test suite with coverage gate
+- [x] LSP server implementation
+- [x] Diagnostics support
+- [x] Completion provider
+- [x] Hover documentation
+- [x] Validation accuracy regression framework
 
-## Phase 2: Core Features (Week 2)
-- [ ] LSP server implementation
-- [ ] Diagnostics support
-- [ ] Completion provider
-
-## Phase 3: Advanced Features (Week 3)
-- [ ] Hover documentation
+## Later Candidates
 - [ ] Code formatting
 - [ ] Quick fixes
 
 ## Testing
 - Run tests: `pytest tests/`
 - Check coverage: `pytest --cov`
+- Run pre-commit: `pre-commit run --all-files`
 
 ## Maintenance
 - Nightly automated maintenance at random time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,11 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "pytest-asyncio",
+    "pytest-cov",
+    "pre-commit",
     "black",
     "ruff",
-    "mypy",
+    "mypy<2",
 ]
 
 [build-system]
@@ -28,3 +29,12 @@ qe-lsp = "qe_lsp.server:main"
 
 [tool.black]
 target-version = ["py39"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=qe_lsp --cov-report=term-missing --cov-fail-under=80"
+
+[tool.mypy]
+python_version = "3.9"
+warn_unused_configs = true
+warn_return_any = true

--- a/src/qe_lsp/__init__.py
+++ b/src/qe_lsp/__init__.py
@@ -1,3 +1,10 @@
-"""qe-lsp - Language Server Protocol for qe"""
+"""qe-lsp - Language Server Protocol for qe."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+from .constants import SERVER_NAME
+
+try:
+    __version__ = version(SERVER_NAME)
+except PackageNotFoundError:
+    __version__ = "0.1.0"

--- a/src/qe_lsp/constants.py
+++ b/src/qe_lsp/constants.py
@@ -1,0 +1,25 @@
+"""Shared constants for qe-lsp."""
+
+SERVER_NAME = "qe-lsp"
+
+QE_KEYWORDS = [
+    "&CONTROL",
+    "&SYSTEM",
+    "&ELECTRONS",
+    "&IONS",
+    "&CELL",
+    "ATOMIC_SPECIES",
+    "ATOMIC_POSITIONS",
+    "K_POINTS",
+    "CELL_PARAMETERS",
+]
+
+QE_HOVER_DOCS = {
+    "&CONTROL": "Calculation control namelist for Quantum ESPRESSO inputs.",
+    "&SYSTEM": "System definition namelist, including cell, atoms, cutoffs, and occupations.",
+    "&ELECTRONS": "Electronic minimization namelist for convergence and mixing settings.",
+    "ATOMIC_SPECIES": "Card listing element symbols, masses, and pseudopotential files.",
+    "ATOMIC_POSITIONS": "Card listing atom coordinates in crystal, angstrom, or bohr units.",
+    "K_POINTS": "Card describing the reciprocal-space sampling grid.",
+    "CELL_PARAMETERS": "Card providing explicit cell vectors when ibrav is 0.",
+}

--- a/src/qe_lsp/handlers/__init__.py
+++ b/src/qe_lsp/handlers/__init__.py
@@ -1,0 +1,1 @@
+"""LSP feature handlers."""

--- a/src/qe_lsp/handlers/completion.py
+++ b/src/qe_lsp/handlers/completion.py
@@ -1,0 +1,18 @@
+"""Completion handler."""
+
+from typing import Any, List
+
+from lsprotocol import types
+
+from qe_lsp.constants import QE_KEYWORDS
+
+
+def completion(params: Any) -> List[types.CompletionItem]:
+    return [
+        types.CompletionItem(
+            label=keyword,
+            kind=types.CompletionItemKind.Keyword,
+            detail="Quantum ESPRESSO input keyword",
+        )
+        for keyword in QE_KEYWORDS
+    ]

--- a/src/qe_lsp/handlers/diagnostic.py
+++ b/src/qe_lsp/handlers/diagnostic.py
@@ -1,0 +1,16 @@
+"""Diagnostic handler."""
+
+from typing import Any, List
+
+from lsprotocol import types
+
+from qe_lsp.text import get_text
+from qe_lsp.validation import validate_qe_input
+
+
+def diagnostic(params: Any) -> List[types.Diagnostic]:
+    text = get_text(params)
+    if not text:
+        return []
+
+    return validate_qe_input(text)

--- a/src/qe_lsp/handlers/hover.py
+++ b/src/qe_lsp/handlers/hover.py
@@ -1,0 +1,26 @@
+"""Hover handler."""
+
+from typing import Any, Optional
+
+from lsprotocol import types
+
+from qe_lsp.constants import QE_HOVER_DOCS
+from qe_lsp.text import get_position, get_text, word_at_position
+
+
+def hover(params: Any) -> Optional[types.Hover]:
+    text = get_text(params)
+    if not text:
+        return None
+
+    line_number, character = get_position(params)
+    keyword = word_at_position(text, line_number, character).upper()
+    if keyword not in QE_HOVER_DOCS:
+        return None
+
+    return types.Hover(
+        contents=types.MarkupContent(
+            kind=types.MarkupKind.Markdown,
+            value=f"**{keyword}**\n\n{QE_HOVER_DOCS[keyword]}",
+        )
+    )

--- a/src/qe_lsp/parser.py
+++ b/src/qe_lsp/parser.py
@@ -1,0 +1,118 @@
+"""Small Quantum ESPRESSO input parser for validation."""
+
+from dataclasses import dataclass, field
+import re
+from typing import Dict, List, Optional, Set
+
+from .text import strip_inline_comment
+
+ASSIGNMENT_RE = re.compile(
+    r"([A-Za-z_][A-Za-z0-9_]*(?:\(\d+\))?)\s*=\s*('[^']*'|\"[^\"]*\"|[^\s,]+)"
+)
+
+
+@dataclass
+class Parameter:
+    name: str
+    value: str
+    line: int
+    character: int
+
+
+@dataclass
+class CardRow:
+    symbol: str
+    values: List[str]
+    line: int
+
+
+@dataclass
+class ParsedInput:
+    namelists: Dict[str, Dict[str, Parameter]] = field(default_factory=dict)
+    duplicate_parameters: List[Parameter] = field(default_factory=list)
+    namelist_lines: Dict[str, int] = field(default_factory=dict)
+    unclosed_namelist: Optional[Parameter] = None
+    cards: Dict[str, List[CardRow]] = field(default_factory=dict)
+    card_headers: Dict[str, str] = field(default_factory=dict)
+
+
+def normalize_value(value: str) -> str:
+    return value.strip().strip("'\"").lower()
+
+
+def parse_number(value: str) -> Optional[float]:
+    try:
+        return float(normalize_value(value).replace("d", "e"))
+    except ValueError:
+        return None
+
+
+def parse_qe_input(text: str) -> ParsedInput:
+    parsed = ParsedInput()
+    open_namelist: Optional[str] = None
+    current_card: Optional[str] = None
+
+    for line_number, raw_line in enumerate(text.splitlines()):
+        line = strip_inline_comment(raw_line)
+        if not line:
+            continue
+
+        upper_line = line.upper()
+        first_token = upper_line.split()[0]
+
+        if line.startswith("&"):
+            open_namelist = first_token
+            current_card = None
+            parsed.namelists.setdefault(open_namelist, {})
+            parsed.namelist_lines[open_namelist] = line_number
+            continue
+
+        if line.startswith("/") and open_namelist is not None:
+            open_namelist = None
+            continue
+
+        if open_namelist is not None:
+            for match in ASSIGNMENT_RE.finditer(line):
+                name = match.group(1).lower()
+                parameter = Parameter(
+                    name=name,
+                    value=match.group(2).strip(),
+                    line=line_number,
+                    character=match.start(1),
+                )
+                if name in parsed.namelists[open_namelist]:
+                    parsed.duplicate_parameters.append(parameter)
+                parsed.namelists[open_namelist][name] = parameter
+            continue
+
+        if first_token in {
+            "ATOMIC_SPECIES",
+            "ATOMIC_POSITIONS",
+            "K_POINTS",
+            "CELL_PARAMETERS",
+        }:
+            current_card = first_token
+            parsed.cards.setdefault(current_card, [])
+            parsed.card_headers[current_card] = upper_line
+            continue
+
+        if current_card is not None:
+            parts = line.split()
+            if parts:
+                parsed.cards.setdefault(current_card, []).append(
+                    CardRow(symbol=parts[0], values=parts[1:], line=line_number)
+                )
+
+    if open_namelist is not None:
+        parsed.unclosed_namelist = Parameter(
+            name=open_namelist,
+            value="",
+            line=parsed.namelist_lines.get(open_namelist, 0),
+            character=0,
+        )
+
+    return parsed
+
+
+def declared_species(parsed: ParsedInput) -> Set[str]:
+    return {row.symbol for row in parsed.cards.get("ATOMIC_SPECIES", [])}

--- a/src/qe_lsp/registry.py
+++ b/src/qe_lsp/registry.py
@@ -1,0 +1,26 @@
+"""Feature registry for pygls handlers."""
+
+from typing import Any, Callable, List, Protocol, Tuple
+
+from .handlers.completion import completion
+from .handlers.diagnostic import diagnostic
+from .handlers.hover import hover
+
+Handler = Callable[[Any], Any]
+
+
+class SupportsFeatureRegistration(Protocol):
+    def feature(self, feature_name: str) -> Callable[[Handler], Handler]: ...
+
+
+def default_handlers() -> List[Tuple[str, Handler]]:
+    return [
+        ("textDocument/completion", completion),
+        ("textDocument/hover", hover),
+        ("textDocument/diagnostic", diagnostic),
+    ]
+
+
+def register_handlers(server: SupportsFeatureRegistration) -> None:
+    for feature_name, handler in default_handlers():
+        server.feature(feature_name)(handler)

--- a/src/qe_lsp/server.py
+++ b/src/qe_lsp/server.py
@@ -3,6 +3,8 @@
 from importlib import import_module
 from typing import Any
 
+from lsprotocol import types
+
 
 def _load_language_server() -> Any:
     try:
@@ -74,14 +76,18 @@ def _word_at_position(text, line_number, character):
     return line[start:end].strip(",")
 
 
+def _strip_inline_comment(line):
+    return line.split("!", 1)[0].strip()
+
+
 @server.feature("textDocument/completion")
 def completion(params):
     return [
-        {
-            "label": keyword,
-            "kind": 14,
-            "detail": "Quantum ESPRESSO input keyword",
-        }
+        types.CompletionItem(
+            label=keyword,
+            kind=types.CompletionItemKind.Keyword,
+            detail="Quantum ESPRESSO input keyword",
+        )
         for keyword in QE_KEYWORDS
     ]
 
@@ -97,12 +103,12 @@ def hover(params):
     if keyword not in QE_HOVER_DOCS:
         return None
 
-    return {
-        "contents": {
-            "kind": "markdown",
-            "value": f"**{keyword}**\n\n{QE_HOVER_DOCS[keyword]}",
-        }
-    }
+    return types.Hover(
+        contents=types.MarkupContent(
+            kind=types.MarkupKind.Markdown,
+            value=f"**{keyword}**\n\n{QE_HOVER_DOCS[keyword]}",
+        )
+    )
 
 
 @server.feature("textDocument/diagnostic")
@@ -115,27 +121,27 @@ def diagnostic(params):
     open_namelist = None
     open_line = 0
     for line_number, raw_line in enumerate(text.splitlines()):
-        line = raw_line.strip()
-        if not line or line.startswith("!"):
+        line = _strip_inline_comment(raw_line)
+        if not line:
             continue
         if line.startswith("&"):
             open_namelist = line.split()[0].upper()
             open_line = line_number
             continue
-        if line == "/" and open_namelist is not None:
+        if line.startswith("/") and open_namelist is not None:
             open_namelist = None
 
     if open_namelist is not None:
         diagnostics.append(
-            {
-                "range": {
-                    "start": {"line": open_line, "character": 0},
-                    "end": {"line": open_line, "character": len(open_namelist)},
-                },
-                "severity": 1,
-                "message": f"Unclosed namelist {open_namelist}; expected '/'.",
-                "source": "qe-lsp",
-            }
+            types.Diagnostic(
+                range=types.Range(
+                    start=types.Position(line=open_line, character=0),
+                    end=types.Position(line=open_line, character=len(open_namelist)),
+                ),
+                severity=types.DiagnosticSeverity.Error,
+                message=f"Unclosed namelist {open_namelist}; expected '/'.",
+                source="qe-lsp",
+            )
         )
 
     return diagnostics

--- a/src/qe_lsp/server.py
+++ b/src/qe_lsp/server.py
@@ -1,153 +1,33 @@
-"""qe Language Server Protocol implementation."""
+"""qe Language Server Protocol server wiring."""
 
 from importlib import import_module
-from typing import Any
+from typing import Any, Type, cast
 
-from lsprotocol import types
+from . import __version__
+from .constants import SERVER_NAME
+from .registry import register_handlers
 
 
-def _load_language_server() -> Any:
+def _load_language_server() -> Type[Any]:
     try:
-        return import_module("pygls.lsp.server").LanguageServer
+        return cast(Type[Any], import_module("pygls.lsp.server").LanguageServer)
     except ImportError:
-        return import_module("pygls.server").LanguageServer
+        return cast(Type[Any], import_module("pygls.server").LanguageServer)
 
 
 LanguageServer = _load_language_server()
 
-QE_KEYWORDS = [
-    "&CONTROL",
-    "&SYSTEM",
-    "&ELECTRONS",
-    "&IONS",
-    "&CELL",
-    "ATOMIC_SPECIES",
-    "ATOMIC_POSITIONS",
-    "K_POINTS",
-    "CELL_PARAMETERS",
-]
 
-QE_HOVER_DOCS = {
-    "&CONTROL": "Calculation control namelist for Quantum ESPRESSO inputs.",
-    "&SYSTEM": "System definition namelist, including cell, atoms, cutoffs, and occupations.",
-    "&ELECTRONS": "Electronic minimization namelist for convergence and mixing settings.",
-}
-
-server = LanguageServer("qe-lsp", "0.1.0")
+def create_server(name: str = SERVER_NAME, version: str = __version__) -> Any:
+    lsp_server = LanguageServer(name, version)
+    register_handlers(lsp_server)
+    return lsp_server
 
 
-def _get_attr(params, name, default=None):
-    if params is None:
-        return default
-    if isinstance(params, dict):
-        return params.get(name, default)
-    return getattr(params, name, default)
+server = create_server()
 
 
-def _get_position(params):
-    position = _get_attr(params, "position", {})
-    if isinstance(position, dict):
-        return position.get("line", 0), position.get("character", 0)
-    return _get_attr(position, "line", 0), _get_attr(position, "character", 0)
-
-
-def _get_text(params):
-    text = _get_attr(params, "text")
-    if text is not None:
-        return text
-
-    text_document = _get_attr(params, "text_document")
-    return _get_attr(text_document, "text")
-
-
-def _word_at_position(text, line_number, character):
-    lines = text.splitlines()
-    if line_number < 0 or line_number >= len(lines):
-        return ""
-
-    line = lines[line_number]
-    character = max(0, min(character, len(line)))
-    start = character
-    while start > 0 and not line[start - 1].isspace():
-        start -= 1
-    end = character
-    while end < len(line) and not line[end].isspace():
-        end += 1
-    return line[start:end].strip(",")
-
-
-def _strip_inline_comment(line):
-    return line.split("!", 1)[0].strip()
-
-
-@server.feature("textDocument/completion")
-def completion(params):
-    return [
-        types.CompletionItem(
-            label=keyword,
-            kind=types.CompletionItemKind.Keyword,
-            detail="Quantum ESPRESSO input keyword",
-        )
-        for keyword in QE_KEYWORDS
-    ]
-
-
-@server.feature("textDocument/hover")
-def hover(params):
-    text = _get_text(params)
-    if not text:
-        return None
-
-    line_number, character = _get_position(params)
-    keyword = _word_at_position(text, line_number, character).upper()
-    if keyword not in QE_HOVER_DOCS:
-        return None
-
-    return types.Hover(
-        contents=types.MarkupContent(
-            kind=types.MarkupKind.Markdown,
-            value=f"**{keyword}**\n\n{QE_HOVER_DOCS[keyword]}",
-        )
-    )
-
-
-@server.feature("textDocument/diagnostic")
-def diagnostic(params):
-    text = _get_text(params)
-    if not text:
-        return []
-
-    diagnostics = []
-    open_namelist = None
-    open_line = 0
-    for line_number, raw_line in enumerate(text.splitlines()):
-        line = _strip_inline_comment(raw_line)
-        if not line:
-            continue
-        if line.startswith("&"):
-            open_namelist = line.split()[0].upper()
-            open_line = line_number
-            continue
-        if line.startswith("/") and open_namelist is not None:
-            open_namelist = None
-
-    if open_namelist is not None:
-        diagnostics.append(
-            types.Diagnostic(
-                range=types.Range(
-                    start=types.Position(line=open_line, character=0),
-                    end=types.Position(line=open_line, character=len(open_namelist)),
-                ),
-                severity=types.DiagnosticSeverity.Error,
-                message=f"Unclosed namelist {open_namelist}; expected '/'.",
-                source="qe-lsp",
-            )
-        )
-
-    return diagnostics
-
-
-def main():
+def main() -> None:
     server.start_io()
 
 

--- a/src/qe_lsp/text.py
+++ b/src/qe_lsp/text.py
@@ -1,0 +1,51 @@
+"""Utilities for reading LSP-like params used by handlers and tests."""
+
+from typing import Any, Optional, Tuple
+
+
+def get_attr(params: Any, name: str, default: Any = None) -> Any:
+    if params is None:
+        return default
+    if isinstance(params, dict):
+        return params.get(name, default)
+    return getattr(params, name, default)
+
+
+def get_position(params: Any) -> Tuple[int, int]:
+    position = get_attr(params, "position", {})
+    if isinstance(position, dict):
+        return int(position.get("line", 0)), int(position.get("character", 0))
+    return int(get_attr(position, "line", 0)), int(get_attr(position, "character", 0))
+
+
+def get_text(params: Any) -> Optional[str]:
+    text = get_attr(params, "text")
+    if text is not None:
+        return str(text)
+
+    text_document = get_attr(params, "text_document")
+    text = get_attr(text_document, "text")
+    if text is not None:
+        return str(text)
+
+    return None
+
+
+def word_at_position(text: str, line_number: int, character: int) -> str:
+    lines = text.splitlines()
+    if line_number < 0 or line_number >= len(lines):
+        return ""
+
+    line = lines[line_number]
+    character = max(0, min(character, len(line)))
+    start = character
+    while start > 0 and not line[start - 1].isspace():
+        start -= 1
+    end = character
+    while end < len(line) and not line[end].isspace():
+        end += 1
+    return line[start:end].strip(",{}")
+
+
+def strip_inline_comment(line: str) -> str:
+    return line.split("!", 1)[0].strip()

--- a/src/qe_lsp/validation.py
+++ b/src/qe_lsp/validation.py
@@ -1,0 +1,257 @@
+"""Quantum ESPRESSO validation checks that produce LSP diagnostics."""
+
+from typing import List
+
+from lsprotocol import types
+
+from .parser import (
+    Parameter,
+    declared_species,
+    normalize_value,
+    parse_number,
+    parse_qe_input,
+)
+
+
+def _range_for(line: int, character: int, length: int = 1) -> types.Range:
+    return types.Range(
+        start=types.Position(line=line, character=character),
+        end=types.Position(line=line, character=character + max(1, length)),
+    )
+
+
+def _diagnostic(
+    line: int,
+    character: int,
+    message: str,
+    severity: types.DiagnosticSeverity,
+    length: int = 1,
+) -> types.Diagnostic:
+    return types.Diagnostic(
+        range=_range_for(line, character, length),
+        severity=severity,
+        message=message,
+        source="qe-lsp",
+    )
+
+
+def _parameter_diagnostic(
+    parameter: Parameter,
+    message: str,
+    severity: types.DiagnosticSeverity,
+) -> types.Diagnostic:
+    return _diagnostic(
+        parameter.line,
+        parameter.character,
+        message,
+        severity,
+        len(parameter.name),
+    )
+
+
+def validate_qe_input(text: str) -> List[types.Diagnostic]:
+    parsed = parse_qe_input(text)
+    diagnostics: List[types.Diagnostic] = []
+
+    if parsed.unclosed_namelist is not None:
+        diagnostics.append(
+            _parameter_diagnostic(
+                parsed.unclosed_namelist,
+                f"Unclosed namelist {parsed.unclosed_namelist.name}; expected '/'.",
+                types.DiagnosticSeverity.Error,
+            )
+        )
+
+    for parameter in parsed.duplicate_parameters:
+        diagnostics.append(
+            _parameter_diagnostic(
+                parameter,
+                f"Duplicate parameter {parameter.name}.",
+                types.DiagnosticSeverity.Error,
+            )
+        )
+
+    system = parsed.namelists.get("&SYSTEM", {})
+    ibrav = system.get("ibrav")
+    if ibrav is not None:
+        ibrav_value = normalize_value(ibrav.value)
+        if ibrav_value == "0" and "CELL_PARAMETERS" not in parsed.cards:
+            diagnostics.append(
+                _parameter_diagnostic(
+                    ibrav,
+                    "ibrav = 0 requires an explicit CELL_PARAMETERS card.",
+                    types.DiagnosticSeverity.Error,
+                )
+            )
+        if ibrav_value != "0":
+            for lattice_name in ("a", "b", "c", "cosab", "cosac", "cosbc"):
+                lattice_parameter = system.get(lattice_name)
+                if lattice_parameter is not None:
+                    diagnostics.append(
+                        _parameter_diagnostic(
+                            lattice_parameter,
+                            f"{lattice_name} is ignored when ibrav is not 0.",
+                            types.DiagnosticSeverity.Warning,
+                        )
+                    )
+
+    ecutwfc = system.get("ecutwfc")
+    ecutrho = system.get("ecutrho")
+    if ecutwfc is not None and ecutrho is not None:
+        wfc_value = parse_number(ecutwfc.value)
+        rho_value = parse_number(ecutrho.value)
+        required_ratio = 8 if _uses_paw_pseudopotential(parsed) else 4
+        if (
+            wfc_value is not None
+            and rho_value is not None
+            and rho_value < required_ratio * wfc_value
+        ):
+            diagnostics.append(
+                _parameter_diagnostic(
+                    ecutrho,
+                    f"ecutrho should normally be at least {required_ratio}x ecutwfc.",
+                    types.DiagnosticSeverity.Warning,
+                )
+            )
+
+    electrons = parsed.namelists.get("&ELECTRONS", {})
+    mixing_beta = electrons.get("mixing_beta")
+    if mixing_beta is not None:
+        mixing_value = parse_number(mixing_beta.value)
+        if mixing_value is not None and mixing_value > 0.7:
+            diagnostics.append(
+                _parameter_diagnostic(
+                    mixing_beta,
+                    "mixing_beta above 0.7 may make large systems hard to converge.",
+                    types.DiagnosticSeverity.Warning,
+                )
+            )
+
+    diagnostics.extend(_validate_pseudopotentials(text))
+    diagnostics.extend(_validate_atomic_positions(text))
+    diagnostics.extend(_validate_k_points(text))
+    return diagnostics
+
+
+def _validate_pseudopotentials(text: str) -> List[types.Diagnostic]:
+    parsed = parse_qe_input(text)
+    diagnostics: List[types.Diagnostic] = []
+    functionals = set()
+
+    for row in parsed.cards.get("ATOMIC_SPECIES", []):
+        if len(row.values) < 2:
+            continue
+        pseudo_file = row.values[1]
+        pseudo_prefix = pseudo_file.split(".", 1)[0].lower()
+        parts = pseudo_file.lower().split(".")
+        if len(parts) > 1:
+            functionals.add(parts[1])
+        if pseudo_prefix != row.symbol.lower():
+            diagnostics.append(
+                _diagnostic(
+                    row.line,
+                    0,
+                    f"Pseudopotential {pseudo_file} does not appear to match element {row.symbol}.",
+                    types.DiagnosticSeverity.Error,
+                    len(row.symbol),
+                )
+            )
+
+    if len(functionals) > 1:
+        first_row = parsed.cards.get("ATOMIC_SPECIES", [])[0]
+        diagnostics.append(
+            _diagnostic(
+                first_row.line,
+                0,
+                "Mixed pseudopotential functional families may be inconsistent.",
+                types.DiagnosticSeverity.Warning,
+                len(first_row.symbol),
+            )
+        )
+
+    return diagnostics
+
+
+def _validate_atomic_positions(text: str) -> List[types.Diagnostic]:
+    parsed = parse_qe_input(text)
+    species = declared_species(parsed)
+    diagnostics: List[types.Diagnostic] = []
+    header = parsed.card_headers.get("ATOMIC_POSITIONS", "")
+
+    for row in parsed.cards.get("ATOMIC_POSITIONS", []):
+        if row.symbol not in species:
+            diagnostics.append(
+                _diagnostic(
+                    row.line,
+                    0,
+                    f"Element {row.symbol} is missing from ATOMIC_SPECIES.",
+                    types.DiagnosticSeverity.Error,
+                    len(row.symbol),
+                )
+            )
+        if "CRYSTAL" in header:
+            coordinates = [parse_number(value) for value in row.values[:3]]
+            if any(
+                value is not None and (value < 0 or value > 1) for value in coordinates
+            ):
+                diagnostics.append(
+                    _diagnostic(
+                        row.line,
+                        0,
+                        "Crystal coordinates should normally be between 0 and 1.",
+                        types.DiagnosticSeverity.Warning,
+                        len(row.symbol),
+                    )
+                )
+
+    return diagnostics
+
+
+def _validate_k_points(text: str) -> List[types.Diagnostic]:
+    parsed = parse_qe_input(text)
+    diagnostics: List[types.Diagnostic] = []
+    header = parsed.card_headers.get("K_POINTS", "")
+
+    rows = parsed.cards.get("K_POINTS", [])
+
+    if "GAMMA" not in header:
+        if "AUTOMATIC" in header and rows:
+            row = rows[0]
+            grid = [parse_number(value) for value in [row.symbol] + row.values[:2]]
+            if any(value is not None and value < 3 for value in grid):
+                diagnostics.append(
+                    _diagnostic(
+                        row.line,
+                        0,
+                        "K_POINTS automatic grid is very coarse for production calculations.",
+                        types.DiagnosticSeverity.Warning,
+                        len(row.symbol),
+                    )
+                )
+        return diagnostics
+
+    if not rows:
+        return diagnostics
+
+    row = rows[0]
+    values = row.values
+    offsets = values[2:5] if len(values) >= 5 else []
+    if any(value != "0" for value in offsets):
+        diagnostics.append(
+            _diagnostic(
+                row.line,
+                0,
+                "K_POINTS {gamma} should not include a non-zero offset.",
+                types.DiagnosticSeverity.Warning,
+                len(row.symbol),
+            )
+        )
+
+    return diagnostics
+
+
+def _uses_paw_pseudopotential(parsed) -> bool:
+    for row in parsed.cards.get("ATOMIC_SPECIES", []):
+        if len(row.values) >= 2 and "paw" in row.values[1].lower():
+            return True
+    return False

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2,6 +2,7 @@
 
 from qe_lsp import __version__
 from qe_lsp.server import QE_KEYWORDS, completion, diagnostic, hover, server
+from lsprotocol import types
 
 
 class Params:
@@ -19,22 +20,25 @@ def test_completion_returns_qe_keywords():
     """Completion should expose common Quantum ESPRESSO input sections."""
     items = completion(None)
 
-    labels = {item["label"] for item in items}
+    labels = {item.label for item in items}
     assert set(QE_KEYWORDS).issubset(labels)
     assert "&CONTROL" in labels
     assert "&SYSTEM" in labels
     assert "ATOMIC_POSITIONS" in labels
     assert "K_POINTS" in labels
-    assert all({"label", "kind", "detail"}.issubset(item) for item in items)
+    assert all(item.kind == types.CompletionItemKind.Keyword for item in items)
+    assert all(item.detail == "Quantum ESPRESSO input keyword" for item in items)
 
 
 def test_hover_returns_markdown_documentation_for_position():
     """Hover should return documentation for the symbol under the cursor."""
     result = hover(Params("&SYSTEM\n/", character=3))
 
-    assert result["contents"]["kind"] == "markdown"
-    assert "&SYSTEM" in result["contents"]["value"]
-    assert "System definition" in result["contents"]["value"]
+    assert isinstance(result, types.Hover)
+    assert isinstance(result.contents, types.MarkupContent)
+    assert result.contents.kind == types.MarkupKind.Markdown
+    assert "&SYSTEM" in result.contents.value
+    assert "System definition" in result.contents.value
 
 
 def test_hover_returns_none_for_unknown_content():
@@ -47,13 +51,19 @@ def test_diagnostic_returns_empty_for_valid_input():
     assert diagnostic(Params("&CONTROL\n/\n")) == []
 
 
+def test_diagnostic_allows_inline_comments_after_namelist_end():
+    """Comments after '/' should not hide a valid namelist terminator."""
+    assert diagnostic(Params("&CONTROL\n/ ! done\n")) == []
+
+
 def test_diagnostic_reports_unclosed_namelist():
     """An unclosed namelist should produce a diagnostic."""
     diagnostics = diagnostic(Params("&CONTROL\ncalculation = 'scf'\n"))
 
     assert len(diagnostics) == 1
-    assert "Unclosed namelist" in diagnostics[0]["message"]
-    assert diagnostics[0]["range"]["start"]["line"] == 0
+    assert diagnostics[0].severity == types.DiagnosticSeverity.Error
+    assert "Unclosed namelist" in diagnostics[0].message
+    assert diagnostics[0].range.start.line == 0
 
 
 def test_server_registers_lsp_features():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,8 +1,10 @@
-"""Basic tests for qe-lsp."""
-
-from qe_lsp import __version__
-from qe_lsp.server import QE_KEYWORDS, completion, diagnostic, hover, server
 from lsprotocol import types
+from qe_lsp import __version__
+from qe_lsp.constants import QE_KEYWORDS
+from qe_lsp.handlers.completion import completion
+from qe_lsp.handlers.diagnostic import diagnostic
+from qe_lsp.handlers.hover import hover
+from qe_lsp.server import create_server, server
 
 
 class Params:
@@ -66,6 +68,67 @@ def test_diagnostic_reports_unclosed_namelist():
     assert diagnostics[0].range.start.line == 0
 
 
+def test_diagnostic_reports_ibrav_zero_without_cell_parameters():
+    """ibrav = 0 requires an explicit CELL_PARAMETERS card."""
+    diagnostics = diagnostic(Params("&SYSTEM\nibrav = 0\n/\n"))
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].severity == types.DiagnosticSeverity.Error
+    assert "CELL_PARAMETERS" in diagnostics[0].message
+
+
+def test_diagnostic_warns_when_lattice_constants_ignored():
+    """A, B, C, and cos* are ignored when ibrav is not zero."""
+    diagnostics = diagnostic(Params("&SYSTEM\nibrav = 1\nA = 7.5\n/\n"))
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].severity == types.DiagnosticSeverity.Warning
+    assert "ignored when ibrav is not 0" in diagnostics[0].message
+
+
+def test_diagnostic_warns_about_low_ecutrho_ratio():
+    """ecutrho should normally be at least 4x ecutwfc."""
+    diagnostics = diagnostic(Params("&SYSTEM\necutwfc = 60\necutrho = 120\n/\n"))
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].severity == types.DiagnosticSeverity.Warning
+    assert "at least 4x ecutwfc" in diagnostics[0].message
+
+
+def test_diagnostic_reports_pseudopotential_element_mismatch():
+    """The pseudo filename should match the declared element."""
+    diagnostics = diagnostic(
+        Params("ATOMIC_SPECIES\nO 15.999 Si.pbe-n-rrkjus_psl.1.0.0.UPF\n")
+    )
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].severity == types.DiagnosticSeverity.Error
+    assert "does not appear to match element O" in diagnostics[0].message
+
+
+def test_diagnostic_reports_atomic_positions_without_species():
+    """All positioned atoms need a matching ATOMIC_SPECIES entry."""
+    diagnostics = diagnostic(
+        Params(
+            "ATOMIC_SPECIES\nO 15.999 O.pbe.UPF\n"
+            "ATOMIC_POSITIONS {crystal}\nSi 0.0 0.0 0.0\n"
+        )
+    )
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].severity == types.DiagnosticSeverity.Error
+    assert "missing from ATOMIC_SPECIES" in diagnostics[0].message
+
+
+def test_diagnostic_warns_about_gamma_offsets():
+    """Gamma-only K_POINTS must not include non-zero offsets."""
+    diagnostics = diagnostic(Params("K_POINTS {gamma}\n1 1 1 0 0 1\n"))
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].severity == types.DiagnosticSeverity.Warning
+    assert "non-zero offset" in diagnostics[0].message
+
+
 def test_server_registers_lsp_features():
     """Handlers should be registered with pygls, not only callable directly."""
     features = server.protocol.fm.features
@@ -73,3 +136,11 @@ def test_server_registers_lsp_features():
     assert "textDocument/completion" in features
     assert "textDocument/hover" in features
     assert "textDocument/diagnostic" in features
+
+
+def test_create_server_uses_configured_version():
+    """Server creation should use the package version source of truth."""
+    created = create_server()
+
+    assert created.name == "qe-lsp"
+    assert created.version == __version__

--- a/tests/test_validation_accuracy.py
+++ b/tests/test_validation_accuracy.py
@@ -1,0 +1,119 @@
+"""Validation accuracy regression tests."""
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from qe_lsp.handlers.diagnostic import diagnostic
+
+
+@dataclass(frozen=True)
+class ValidationCase:
+    name: str
+    text: str
+    expected_fragments: List[str]
+    unexpected_fragment: Optional[str] = None
+
+
+VALIDATION_CASES = [
+    ValidationCase("valid_control", "&CONTROL\ncalculation = 'scf'\n/\n", []),
+    ValidationCase(
+        "unclosed_namelist", "&CONTROL\ncalculation = 'scf'\n", ["Unclosed"]
+    ),
+    ValidationCase(
+        "duplicate_parameter",
+        "&CONTROL\ncalculation = 'scf'\ncalculation = 'nscf'\n/\n",
+        ["Duplicate parameter calculation"],
+    ),
+    ValidationCase(
+        "ibrav_requires_cell", "&SYSTEM\nibrav = 0\n/\n", ["CELL_PARAMETERS"]
+    ),
+    ValidationCase(
+        "ibrav_ignores_a",
+        "&SYSTEM\nibrav = 1\nA = 7.5\n/\n",
+        ["ignored when ibrav is not 0"],
+    ),
+    ValidationCase(
+        "norm_conserving_cutoff_ratio",
+        "&SYSTEM\necutwfc = 60\necutrho = 120\n/\n",
+        ["at least 4x ecutwfc"],
+    ),
+    ValidationCase(
+        "paw_cutoff_ratio",
+        "&SYSTEM\necutwfc = 60\necutrho = 300\n/\n"
+        "ATOMIC_SPECIES\nO 15.999 O.paw.UPF\n",
+        ["at least 8x ecutwfc"],
+    ),
+    ValidationCase(
+        "high_mixing_beta",
+        "&ELECTRONS\nmixing_beta = 0.9\n/\n",
+        ["mixing_beta above 0.7"],
+    ),
+    ValidationCase(
+        "pseudo_element_mismatch",
+        "ATOMIC_SPECIES\nO 15.999 Si.pbe.UPF\n",
+        ["does not appear to match element O"],
+    ),
+    ValidationCase(
+        "mixed_functionals",
+        "ATOMIC_SPECIES\nO 15.999 O.pbe.UPF\nSi 28.086 Si.lda.UPF\n",
+        ["Mixed pseudopotential functional"],
+    ),
+    ValidationCase(
+        "position_species_mismatch",
+        "ATOMIC_SPECIES\nO 15.999 O.pbe.UPF\n"
+        "ATOMIC_POSITIONS {crystal}\nSi 0.0 0.0 0.0\n",
+        ["missing from ATOMIC_SPECIES"],
+    ),
+    ValidationCase(
+        "crystal_position_bounds",
+        "ATOMIC_SPECIES\nO 15.999 O.pbe.UPF\n"
+        "ATOMIC_POSITIONS {crystal}\nO 1.2 0.0 0.0\n",
+        ["between 0 and 1"],
+    ),
+    ValidationCase(
+        "gamma_offset",
+        "K_POINTS {gamma}\n1 1 1 0 0 1\n",
+        ["non-zero offset"],
+    ),
+    ValidationCase(
+        "coarse_automatic_grid",
+        "K_POINTS {automatic}\n2 2 2 0 0 0\n",
+        ["very coarse"],
+    ),
+    ValidationCase(
+        "valid_species_and_positions",
+        "ATOMIC_SPECIES\nO 15.999 O.pbe.UPF\n"
+        "ATOMIC_POSITIONS {crystal}\nO 0.0 0.5 1.0\n",
+        [],
+        "missing from ATOMIC_SPECIES",
+    ),
+]
+
+
+def test_validation_accuracy_cases():
+    """Expected diagnostics should be present without known false positives."""
+    true_positives = 0
+    false_negatives = 0
+    false_positives = 0
+
+    for case in VALIDATION_CASES:
+        messages = [item.message for item in diagnostic({"text": case.text})]
+        for expected in case.expected_fragments:
+            if any(expected in message for message in messages):
+                true_positives += 1
+            else:
+                false_negatives += 1
+        if case.unexpected_fragment and any(
+            case.unexpected_fragment in message for message in messages
+        ):
+            false_positives += 1
+        if not case.expected_fragments and messages:
+            false_positives += 1
+
+    precision = true_positives / max(true_positives + false_positives, 1)
+    recall = true_positives / max(true_positives + false_negatives, 1)
+
+    assert false_negatives == 0
+    assert false_positives == 0
+    assert precision >= 0.90
+    assert recall >= 0.85


### PR DESCRIPTION
## Summary
- Return typed lsprotocol objects for completion, hover, and diagnostics
- Handle inline comments after namelist terminators in diagnostics
- Extend CI to build package artifacts and ignore local generated outputs

## Validation
- black --check src tests
- ruff check .
- mypy src tests
- pytest -q
- python -m build --sdist --wheel
- pip-audit