### PR TITLE
test: add real-world Quantum ESPRESSO parse fixtures

### DIFF
--- a/tests/fixtures/qe_inputs/README.md
+++ b/tests/fixtures/qe_inputs/README.md
@@ -1,0 +1,23 @@
+# Quantum ESPRESSO Input Fixtures
+
+These fixtures are small public `pw.x` inputs from the official Quantum ESPRESSO
+GitHub mirror, copied for parser regression coverage.
+
+Upstream repository: https://github.com/QEF/q-e
+
+Upstream commit: `0f3d9044f2e553b900550e8f0f18b3cb416f13b6`
+
+License: GNU General Public License v2.0 (`GPL-2.0`), as reported by the GitHub
+repository metadata. Upstream license file:
+https://github.com/QEF/q-e/blob/0f3d9044f2e553b900550e8f0f18b3cb416f13b6/License
+
+Retrieved: 2026-06-09
+
+## Files
+
+| Local file | Upstream source |
+| --- | --- |
+| `qe_test_suite_pw_scf_scf.in` | https://github.com/QEF/q-e/blob/0f3d9044f2e553b900550e8f0f18b3cb416f13b6/test-suite/pw_scf/scf.in |
+| `qe_test_suite_pw_metal_tetrahedra.in` | https://github.com/QEF/q-e/blob/0f3d9044f2e553b900550e8f0f18b3cb416f13b6/test-suite/pw_metal/metal-tetrahedra.in |
+| `qe_test_suite_pw_lattice_ibrav0_cell_parameters.in` | https://github.com/QEF/q-e/blob/0f3d9044f2e553b900550e8f0f18b3cb416f13b6/test-suite/pw_lattice-ibrav/lattice-ibrav0-cell_parameters.in |
+| `qe_test_suite_pw_relax_relax.in` | https://github.com/QEF/q-e/blob/0f3d9044f2e553b900550e8f0f18b3cb416f13b6/test-suite/pw_relax/relax.in |

--- a/tests/fixtures/qe_inputs/qe_test_suite_pw_lattice_ibrav0_cell_parameters.in
+++ b/tests/fixtures/qe_inputs/qe_test_suite_pw_lattice_ibrav0_cell_parameters.in
@@ -1,0 +1,21 @@
+ &control
+    calculation='scf',
+ /
+ &system
+    ibrav = 0
+    nat=2, ntyp=1,
+    nbnd = 4,
+    ecutwfc = 25.0
+ /
+ &electrons conv_thr = 1.d-8
+ /
+ATOMIC_SPECIES
+ H 1.0008   H.pz-vbc.UPF
+ATOMIC_POSITIONS {angstrom}
+ H  0.00 0.00 -0.35
+ H  0.00 0.00  0.35
+CELL_PARAMETERS bohr
+  10.00000   0.00000   0.00000
+   4.50000  14.30909   0.00000
+   4.00000   0.83863  19.57796
+K_POINTS {gamma}

--- a/tests/fixtures/qe_inputs/qe_test_suite_pw_metal_tetrahedra.in
+++ b/tests/fixtures/qe_inputs/qe_test_suite_pw_metal_tetrahedra.in
@@ -1,0 +1,17 @@
+ &control
+    calculation='scf'
+ /
+ &system
+    ibrav=2, celldm(1) =7.50,
+    nat=1, ntyp=1,
+    ecutwfc =15.0,
+    occupations='tetrahedra-opt'
+ /
+ &electrons
+ /
+ATOMIC_SPECIES
+ Al  26.98 Al.pz-vbc.UPF
+ATOMIC_POSITIONS (alat)
+ Al 0.00 0.00 0.00
+K_POINTS {automatic}
+ 4 4 4 1 1 1

--- a/tests/fixtures/qe_inputs/qe_test_suite_pw_relax_relax.in
+++ b/tests/fixtures/qe_inputs/qe_test_suite_pw_relax_relax.in
@@ -1,0 +1,23 @@
+&CONTROL
+  calculation  = "relax"
+/
+&SYSTEM
+  ibrav     = 1,
+  celldm(1) =12.0,
+  nat       = 2,
+  ntyp      = 2,
+  ecutwfc   = 24.D0,
+  ecutrho   = 144.D0,
+/
+&ELECTRONS
+  conv_thr  = 1.0e-7
+/
+&IONS
+/
+ATOMIC_SPECIES
+O  1.00  O.pz-rrkjus.UPF
+C  1.00  C.pz-rrkjus.UPF
+ATOMIC_POSITIONS {bohr}
+C  2.256  0.0  0.0
+O  0.000  0.0  0.0  0 0 0
+K_POINTS {Gamma}

--- a/tests/fixtures/qe_inputs/qe_test_suite_pw_scf_scf.in
+++ b/tests/fixtures/qe_inputs/qe_test_suite_pw_scf_scf.in
@@ -1,0 +1,20 @@
+ &control
+    calculation = 'scf'
+    tstress=.true.
+ /
+ &system
+    ibrav=2, celldm(1) =10.20,
+    nat=2, ntyp=1,
+    ecutwfc=12.0
+ /
+ &electrons
+ /
+ATOMIC_SPECIES
+ Si  28.086  Si.pz-vbc.UPF
+ATOMIC_POSITIONS (alat)
+ Si 0.00 0.00 0.00
+ Si 0.25 0.25 0.25
+K_POINTS
+  2
+   0.250000  0.250000  0.250000   1.00
+   0.250000  0.250000  0.750000   3.00

--- a/tests/test_real_world_qe_fixtures.py
+++ b/tests/test_real_world_qe_fixtures.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+import pytest
+
+from qe_lsp.parser import parse_qe_input
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "qe_inputs"
+
+FIXTURE_CASES = [
+    pytest.param(
+        "qe_test_suite_pw_scf_scf.in",
+        {
+            "namelists": {"&CONTROL", "&SYSTEM", "&ELECTRONS"},
+            "cards": {"ATOMIC_SPECIES", "ATOMIC_POSITIONS", "K_POINTS"},
+            "parameters": {
+                "&CONTROL": {"calculation": "'scf'"},
+                "&SYSTEM": {"ibrav": "2", "nat": "2", "ntyp": "1"},
+            },
+            "species": ["Si"],
+            "card_lengths": {"ATOMIC_POSITIONS": 2, "K_POINTS": 3},
+        },
+        id="pw_scf_scf",
+    ),
+    pytest.param(
+        "qe_test_suite_pw_metal_tetrahedra.in",
+        {
+            "namelists": {"&CONTROL", "&SYSTEM", "&ELECTRONS"},
+            "cards": {"ATOMIC_SPECIES", "ATOMIC_POSITIONS", "K_POINTS"},
+            "parameters": {
+                "&CONTROL": {"calculation": "'scf'"},
+                "&SYSTEM": {"occupations": "'tetrahedra-opt'", "nat": "1", "ntyp": "1"},
+            },
+            "species": ["Al"],
+            "card_lengths": {"ATOMIC_POSITIONS": 1, "K_POINTS": 1},
+        },
+        id="pw_metal_tetrahedra",
+    ),
+    pytest.param(
+        "qe_test_suite_pw_lattice_ibrav0_cell_parameters.in",
+        {
+            "namelists": {"&CONTROL", "&SYSTEM", "&ELECTRONS"},
+            "cards": {
+                "ATOMIC_SPECIES",
+                "ATOMIC_POSITIONS",
+                "CELL_PARAMETERS",
+                "K_POINTS",
+            },
+            "parameters": {
+                "&CONTROL": {"calculation": "'scf'"},
+                "&SYSTEM": {"ibrav": "0", "nat": "2", "ntyp": "1"},
+            },
+            "species": ["H"],
+            "card_lengths": {"ATOMIC_POSITIONS": 2, "CELL_PARAMETERS": 3, "K_POINTS": 0},
+        },
+        id="pw_lattice_ibrav0_cell_parameters",
+    ),
+    pytest.param(
+        "qe_test_suite_pw_relax_relax.in",
+        {
+            "namelists": {"&CONTROL", "&SYSTEM", "&ELECTRONS", "&IONS"},
+            "cards": {"ATOMIC_SPECIES", "ATOMIC_POSITIONS", "K_POINTS"},
+            "parameters": {
+                "&CONTROL": {"calculation": '"relax"'},
+                "&SYSTEM": {"ibrav": "1", "nat": "2", "ntyp": "2"},
+            },
+            "species": ["O", "C"],
+            "card_lengths": {"ATOMIC_POSITIONS": 2, "K_POINTS": 0},
+        },
+        id="pw_relax_relax",
+    ),
+]
+
+
+@pytest.mark.parametrize("filename, expected", FIXTURE_CASES)
+def test_public_qe_input_fixtures_parse_expected_namelists_and_cards(filename, expected):
+    text = (FIXTURE_DIR / filename).read_text(encoding="utf-8")
+
+    parsed = parse_qe_input(text)
+
+    assert parsed.unclosed_namelist is None
+    assert parsed.duplicate_parameters == []
+    assert expected["namelists"].issubset(parsed.namelists)
+    assert expected["cards"].issubset(parsed.cards)
+
+    for namelist, parameters in expected["parameters"].items():
+        for name, value in parameters.items():
+            assert parsed.namelists[namelist][name].value == value
+
+    assert [row.symbol for row in parsed.cards["ATOMIC_SPECIES"]] == expected["species"]
+    for card, length in expected["card_lengths"].items():
+        assert len(parsed.cards[card]) == length


### PR DESCRIPTION
## Summary

- add official Quantum ESPRESSO `pw.x` input examples as real-world parser fixtures
- document upstream source URLs, commit, retrieval date, and GPL-2.0 license reference
- add a parse regression test that validates expected namelists, cards, parameters, species, and card row counts

Refs #50 #51 #52

## Sources

Fixtures were copied from the public `QEF/q-e` test-suite at commit `0f3d9044f2e553b900550e8f0f18b3cb416f13b6`:

- `test-suite/pw_scf/scf.in`
- `test-suite/pw_metal/metal-tetrahedra.in`
- `test-suite/pw_lattice-ibrav/lattice-ibrav0-cell_parameters.in`
- `test-suite/pw_relax/relax.in`

## Verification

- `PYTHONPATH=src python3 -m pytest tests/test_real_world_qe_fixtures.py --no-cov` -> 4 passed
- `python3 -m black --check tests/test_real_world_qe_fixtures.py`
- `git diff --cached --check`
