### PR TITLE
chore: clean QE LSP quality gates

### DIFF
--- a/src/qe_lsp/features/agent_api.py
+++ b/src/qe_lsp/features/agent_api.py
@@ -18,29 +18,53 @@ class AgentAPISnapshot:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def to_json(self) -> str:
-        return json.dumps({"uri": self.uri, "version": self.version,
-            "diagnostics": self.diagnostics, "outline": self.outline,
-            "metadata": self.metadata}, indent=2)
+        return json.dumps(
+            {
+                "uri": self.uri,
+                "version": self.version,
+                "diagnostics": self.diagnostics,
+                "outline": self.outline,
+                "metadata": self.metadata,
+            },
+            indent=2,
+        )
 
 
 def _diag_to_dict(d: Diagnostic) -> Dict[str, Any]:
-    return {"line": d.range.start.line, "character": d.range.start.character,
-        "severity": d.severity, "message": d.message, "code": d.code, "source": d.source}
+    return {
+        "line": d.range.start.line,
+        "character": d.range.start.character,
+        "severity": d.severity,
+        "message": d.message,
+        "code": d.code,
+        "source": d.source,
+    }
 
 
 class AgentAPIProvider:
     def __init__(self) -> None:
         pass
 
-    def get_snapshot(self, source: str, uri: str = "",
-        version: Optional[int] = None, diagnostics: Optional[List[Diagnostic]] = None,
+    def get_snapshot(
+        self,
+        source: str,
+        uri: str = "",
+        version: Optional[int] = None,
+        diagnostics: Optional[List[Diagnostic]] = None,
     ) -> AgentAPISnapshot:
         diag_dicts = [_diag_to_dict(d) for d in (diagnostics or [])]
         outline = self._build_outline(source)
-        return AgentAPISnapshot(uri=uri, version=version,
-            diagnostics=diag_dicts, outline=outline,
-            metadata={"language": "quantum-espresso", "provider": "qe_lsp",
-                "feature_count": {"diagnostics": len(diag_dicts), "outline_items": len(outline)}})
+        return AgentAPISnapshot(
+            uri=uri,
+            version=version,
+            diagnostics=diag_dicts,
+            outline=outline,
+            metadata={
+                "language": "quantum-espresso",
+                "provider": "qe_lsp",
+                "feature_count": {"diagnostics": len(diag_dicts), "outline_items": len(outline)},
+            },
+        )
 
     def _build_outline(self, source: str) -> List[Dict[str, Any]]:
         outline: List[Dict[str, Any]] = []
@@ -51,10 +75,14 @@ class AgentAPIProvider:
                 outline.append({"line": i, "text": stripped[:80], "type": "content"})
         return outline
 
-    def get_diagnostics_json(self, source: str, uri: str = "",
-        diagnostics: Optional[List[Diagnostic]] = None) -> str:
+    def get_diagnostics_json(
+        self, source: str, uri: str = "", diagnostics: Optional[List[Diagnostic]] = None
+    ) -> str:
         snap = self.get_snapshot(source, uri, diagnostics=diagnostics)
-        return json.dumps({"uri": snap.uri, "diagnostics": snap.diagnostics, "count": len(snap.diagnostics)}, indent=2)
+        return json.dumps(
+            {"uri": snap.uri, "diagnostics": snap.diagnostics, "count": len(snap.diagnostics)},
+            indent=2,
+        )
 
     def get_outline_json(self, source: str, uri: str = "") -> str:
         snap = self.get_snapshot(source, uri)

--- a/src/qe_lsp/features/code_actions.py
+++ b/src/qe_lsp/features/code_actions.py
@@ -20,9 +20,8 @@ from lsprotocol.types import (
     WorkspaceEdit,
 )
 
-from ..parser import normalize_value, parse_qe_input
+from ..parser import parse_qe_input
 from ..features.lint import (
-    DEPRECATED_KEYWORDS,
     KNOWN_PARAMETERS,
     VALID_NAMELISTS,
     RULE_DEPRECATED_KEYWORD,
@@ -58,7 +57,6 @@ _KEYWORD_TYPOS: dict[str, str] = {
     "ibrav": "ibrav",
     "ibrve": "ibrav",
     "ibarv": "ibrav",
-    "occupations": "occupations",
     "ocupations": "occupations",
     "occupaton": "occupations",
     "occupations": "occupations",
@@ -274,7 +272,6 @@ class CodeActionProvider:
 
         line = lines[line_num]
         raw_name = line.strip().split()[0] if line.strip() else ""
-        lower_name = raw_name.lower()
         upper_name = raw_name.upper()
 
         # Already valid (e.g. truly unknown, not just a casing issue)
@@ -286,7 +283,11 @@ class CodeActionProvider:
                     break
             if correct is not None and raw_name != correct:
                 return self._make_replacement(
-                    diagnostic, line_num, 0, len(raw_name), correct,
+                    diagnostic,
+                    line_num,
+                    0,
+                    len(raw_name),
+                    correct,
                     title=f"Change '{raw_name}' to '{correct}'",
                 )
         return None
@@ -339,18 +340,6 @@ class CodeActionProvider:
 
         line = lines[line_num]
 
-        # Extract the keyword name from the diagnostic range
-        col_start = diagnostic.range.start.character
-        col_end = diagnostic.range.end.character
-        keyword = line[col_start:col_end].strip().lower()
-
-        # Try extracting from message: "Invalid value 'foo' for 'bar'."
-        if "'" in message:
-            parts = message.split("'")
-            # Keyword is at index 3 (fourth segment): for 'bar'
-            if len(parts) >= 4:
-                keyword = parts[3].lower()
-
         # Extract the current invalid value
         from ..parser import ASSIGNMENT_RE
 
@@ -366,7 +355,7 @@ class CodeActionProvider:
         valid_values: set[str] = set()
         if "valid: " in message.lower():
             idx = message.lower().rfind("valid: ")
-            values_str = message[idx + 7:].rstrip(".")
+            values_str = message[idx + 7 :].rstrip(".")
             valid_values = {v.strip().strip("'\"") for v in values_str.split(",")}
 
         if not valid_values:
@@ -758,9 +747,7 @@ class CodeActionProvider:
                         TextEdit(
                             range=Range(
                                 start=Position(line=line, character=col_start),
-                                end=Position(
-                                    line=line, character=col_start + col_end_offset
-                                ),
+                                end=Position(line=line, character=col_start + col_end_offset),
                             ),
                             new_text=new_text,
                         )

--- a/src/qe_lsp/features/diagnostic.py
+++ b/src/qe_lsp/features/diagnostic.py
@@ -2,20 +2,20 @@
 
 from __future__ import annotations
 
-import json
-from dataclasses import asdict
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lsprotocol.types import (
     Diagnostic,
     DiagnosticSeverity,
-    Position,
-    Range,
 )
-try:
+
+if TYPE_CHECKING:
     from pygls.lsp.server import LanguageServer
-except ImportError:
-    from pygls.server import LanguageServer
+else:
+    try:
+        from pygls.lsp.server import LanguageServer
+    except ImportError:
+        from pygls.server import LanguageServer
 
 from ..validation import validate_qe_input
 
@@ -82,6 +82,8 @@ class DiagnosticProvider:
 
 def _severity_name(severity: DiagnosticSeverity | None) -> str:
     """Map a numeric severity to a human-readable label."""
+    if severity is None:
+        return "Information"
     mapping = {
         DiagnosticSeverity.Error: "Error",
         DiagnosticSeverity.Warning: "Warning",

--- a/src/qe_lsp/features/formatting.py
+++ b/src/qe_lsp/features/formatting.py
@@ -7,7 +7,7 @@ Formatting is purely cosmetic: no semantic rewrites are performed.
 
 from __future__ import annotations
 
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from lsprotocol.types import (
     DocumentFormattingParams,
@@ -17,22 +17,21 @@ from lsprotocol.types import (
     TextEdit,
 )
 
-try:
+if TYPE_CHECKING:
     from pygls.lsp.server import LanguageServer
-except ImportError:
-    from pygls.server import LanguageServer
+else:
+    try:
+        from pygls.lsp.server import LanguageServer
+    except ImportError:
+        from pygls.server import LanguageServer
 
 from ..constants import QE_KEYWORDS
 
 #: Namelist headers that start an indented block.
-_NAMELIST_HEADERS: frozenset[str] = frozenset(
-    kw for kw in QE_KEYWORDS if kw.startswith("&")
-)
+_NAMELIST_HEADERS: frozenset[str] = frozenset(kw for kw in QE_KEYWORDS if kw.startswith("&"))
 
 #: Card headers that start an indented block.
-_CARD_HEADERS: frozenset[str] = frozenset(
-    kw for kw in QE_KEYWORDS if not kw.startswith("&")
-)
+_CARD_HEADERS: frozenset[str] = frozenset(kw for kw in QE_KEYWORDS if not kw.startswith("&"))
 
 
 class FormattingProvider:
@@ -41,9 +40,7 @@ class FormattingProvider:
     def __init__(self, server: LanguageServer) -> None:
         self.server = server
 
-    def format_document(
-        self, text: str, params: DocumentFormattingParams
-    ) -> List[TextEdit]:
+    def format_document(self, text: str, params: DocumentFormattingParams) -> List[TextEdit]:
         """Format the entire document.
 
         Args:
@@ -59,11 +56,7 @@ class FormattingProvider:
             return []
 
         indent_size = params.options.tab_size if params.options else 2
-        insert_spaces = (
-            params.options.insert_spaces
-            if params.options
-            else True
-        )
+        insert_spaces = params.options.insert_spaces if params.options else True
         indent_str = " " * indent_size if insert_spaces else "\t"
 
         formatted_lines = self._format_lines(lines, indent_str)
@@ -86,9 +79,7 @@ class FormattingProvider:
             )
         ]
 
-    def format_range(
-        self, text: str, params: DocumentRangeFormattingParams
-    ) -> List[TextEdit]:
+    def format_range(self, text: str, params: DocumentRangeFormattingParams) -> List[TextEdit]:
         """Format a contiguous range of lines.
 
         The range is expanded to include complete logical blocks so that
@@ -113,11 +104,7 @@ class FormattingProvider:
         end_line = max(0, min(end_line, len(lines) - 1))
 
         indent_size = params.options.tab_size if params.options else 2
-        insert_spaces = (
-            params.options.insert_spaces
-            if params.options
-            else True
-        )
+        insert_spaces = params.options.insert_spaces if params.options else True
         indent_str = " " * indent_size if insert_spaces else "\t"
 
         # Determine the indentation context at start_line by scanning

--- a/src/qe_lsp/features/lint.py
+++ b/src/qe_lsp/features/lint.py
@@ -8,7 +8,6 @@ shared parser / keyword infrastructure.
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from lsprotocol.types import (
@@ -18,7 +17,7 @@ from lsprotocol.types import (
     Range,
 )
 
-from ..parser import Parameter, normalize_value, parse_number, parse_qe_input
+from ..parser import normalize_value, parse_number, parse_qe_input
 
 # ------------------------------------------------------------------
 # Rule codes  (QE-Exxx = error, QE-Wxxx = warning, QE-Ixxx = info)
@@ -40,57 +39,175 @@ RULE_ORPHAN_PARAMETER = "QE-W004"
 # Schema data
 # ------------------------------------------------------------------
 
-VALID_NAMELISTS = frozenset({
-    "&CONTROL", "&SYSTEM", "&ELECTRONS", "&IONS", "&CELL",
-})
+VALID_NAMELISTS = frozenset(
+    {
+        "&CONTROL",
+        "&SYSTEM",
+        "&ELECTRONS",
+        "&IONS",
+        "&CELL",
+    }
+)
 
 #: Mapping of namelist -> set of recognised parameter names.
 #: This is intentionally a *subset* of the full QE grammar — it covers
 #: the most common keywords and is the set we lint against.  Unknown
 #: keywords outside this set trigger QE-W001.
 KNOWN_PARAMETERS: dict[str, frozenset[str]] = {
-    "&CONTROL": frozenset({
-        "calculation", "title", "verbosity", "restart_mode", "wf_collect",
-        "nstep", "iprint", "tstress", "tprnfor", "dt", "outdir",
-        "wfcdir", "prefix", "lkpoint_dir", "max_seconds", "etot_conv_thr",
-        "forc_conv_thr", "disk_io", "pseudo_dir", "tefield", "dipfield",
-        "lelfield", "nberrycyc", "lorbm", "lberry", "gdir", "nppstr",
-        "lfcpopt", "gate", "plane_axis",
-    }),
-    "&SYSTEM": frozenset({
-        "ibrav", "a", "b", "c", "cosab", "cosac", "cosbc",
-        "celldm", "celldm(1)", "celldm(2)", "celldm(3)",
-        "celldm(4)", "celldm(5)", "celldm(6)",
-        "nat", "ntyp", "nbnd", "tot_charge", "tot_magnetization",
-        "ecutwfc", "ecutrho", "occupations", "degauss", "smearing",
-        "nspin", "starting_magnetization", "nosym", "nosym_evc",
-        "noinv", "no_t_rev", "force_symmorphic", "use_all_frac",
-        "noncolin", "lspinorb", "lda_plus_u", "lda_plus_u_kind",
-        "hubbard_u", "hubbard_alpha", "hubbard_j", "starting_ns_eigenvalue",
-        "u_projection_type", "edir", "emaxpos", "eopreg", "eamp",
-        "angle1", "angle2", "report", "lxdm", "exx_fraction",
-        "ec_fixed", "screening_parameter", "gcscu", "gcscu2", "gcscu3",
-    }),
-    "&ELECTRONS": frozenset({
-        "conv_thr", "niter", "electron_maxstep", "scf_must_converge",
-        "adaptively", "diagonalization", "mixing_mode", "mixing_beta",
-        "mixing_ndim", "mixing_gg0", "tq_smoothing", "tbeta_smoothing",
-        "diago_thr_init", "diago_cg_maxiter", "diago_david_ndim",
-        "diago_rmm_ndim", "diago_rmm_conv", "diago_full_acc",
-        "efield", "efield_cart", "efield_phase", "startingpot",
-        "startingwfc", "tqr", "real_space",
-    }),
-    "&IONS": frozenset({
-        "ion_dynamics", "ion_positions", "pot_extrapolation",
-        "wfc_extrapolation", "remove_rigid_rot", "bfgs_ndim",
-        "bfgs_w1", "bfgs_w2", "trust_radius_max", "trust_radius_min",
-        "trust_radius_init", "upscale", "ion_nstepe",
-    }),
-    "&CELL": frozenset({
-        "cell_dynamics", "press", "wmass", "cell_factor",
-        "press_conv_thr", "cell_dofree", "isotropic",
-        "fix_volume", "fix_area", "taup", "taub",
-    }),
+    "&CONTROL": frozenset(
+        {
+            "calculation",
+            "title",
+            "verbosity",
+            "restart_mode",
+            "wf_collect",
+            "nstep",
+            "iprint",
+            "tstress",
+            "tprnfor",
+            "dt",
+            "outdir",
+            "wfcdir",
+            "prefix",
+            "lkpoint_dir",
+            "max_seconds",
+            "etot_conv_thr",
+            "forc_conv_thr",
+            "disk_io",
+            "pseudo_dir",
+            "tefield",
+            "dipfield",
+            "lelfield",
+            "nberrycyc",
+            "lorbm",
+            "lberry",
+            "gdir",
+            "nppstr",
+            "lfcpopt",
+            "gate",
+            "plane_axis",
+        }
+    ),
+    "&SYSTEM": frozenset(
+        {
+            "ibrav",
+            "a",
+            "b",
+            "c",
+            "cosab",
+            "cosac",
+            "cosbc",
+            "celldm",
+            "celldm(1)",
+            "celldm(2)",
+            "celldm(3)",
+            "celldm(4)",
+            "celldm(5)",
+            "celldm(6)",
+            "nat",
+            "ntyp",
+            "nbnd",
+            "tot_charge",
+            "tot_magnetization",
+            "ecutwfc",
+            "ecutrho",
+            "occupations",
+            "degauss",
+            "smearing",
+            "nspin",
+            "starting_magnetization",
+            "nosym",
+            "nosym_evc",
+            "noinv",
+            "no_t_rev",
+            "force_symmorphic",
+            "use_all_frac",
+            "noncolin",
+            "lspinorb",
+            "lda_plus_u",
+            "lda_plus_u_kind",
+            "hubbard_u",
+            "hubbard_alpha",
+            "hubbard_j",
+            "starting_ns_eigenvalue",
+            "u_projection_type",
+            "edir",
+            "emaxpos",
+            "eopreg",
+            "eamp",
+            "angle1",
+            "angle2",
+            "report",
+            "lxdm",
+            "exx_fraction",
+            "ec_fixed",
+            "screening_parameter",
+            "gcscu",
+            "gcscu2",
+            "gcscu3",
+        }
+    ),
+    "&ELECTRONS": frozenset(
+        {
+            "conv_thr",
+            "niter",
+            "electron_maxstep",
+            "scf_must_converge",
+            "adaptively",
+            "diagonalization",
+            "mixing_mode",
+            "mixing_beta",
+            "mixing_ndim",
+            "mixing_gg0",
+            "tq_smoothing",
+            "tbeta_smoothing",
+            "diago_thr_init",
+            "diago_cg_maxiter",
+            "diago_david_ndim",
+            "diago_rmm_ndim",
+            "diago_rmm_conv",
+            "diago_full_acc",
+            "efield",
+            "efield_cart",
+            "efield_phase",
+            "startingpot",
+            "startingwfc",
+            "tqr",
+            "real_space",
+        }
+    ),
+    "&IONS": frozenset(
+        {
+            "ion_dynamics",
+            "ion_positions",
+            "pot_extrapolation",
+            "wfc_extrapolation",
+            "remove_rigid_rot",
+            "bfgs_ndim",
+            "bfgs_w1",
+            "bfgs_w2",
+            "trust_radius_max",
+            "trust_radius_min",
+            "trust_radius_init",
+            "upscale",
+            "ion_nstepe",
+        }
+    ),
+    "&CELL": frozenset(
+        {
+            "cell_dynamics",
+            "press",
+            "wmass",
+            "cell_factor",
+            "press_conv_thr",
+            "cell_dofree",
+            "isotropic",
+            "fix_volume",
+            "fix_area",
+            "taup",
+            "taub",
+        }
+    ),
 }
 
 #: Keywords that are deprecated or have recommended replacements.
@@ -100,32 +217,91 @@ DEPRECATED_KEYWORDS: dict[str, str] = {
 }
 
 #: Enum-like value sets for specific keywords.
-VALID_CALCULATIONS = frozenset({
-    "scf", "nscf", "bands", "relax", "md", "vc-relax", "vc-md",
-})
-VALID_DIAGALIZATIONS = frozenset({
-    "david", "cg", "ppcg", "paro", "rmm-davidson", "rmm-paro",
-})
-VALID_MIXING_MODES = frozenset({
-    "plain", "tf", "local-tf",
-})
-VALID_SMEARING = frozenset({
-    "gaussian", "methfessel-paxton", "mp", "mv", "fermi-dirac", "fd",
-})
-VALID_OCCUPATIONS = frozenset({
-    "smearing", "tetrahedra", "tetrahedra_lin", "tetrahedra_opt",
-    "fixed", "from_input",
-})
-VALID_ION_DYNAMICS = frozenset({
-    "none", "bfgs", "damp", "verlet", "langevin", "beeman",
-})
-VALID_CELL_DYNAMICS = frozenset({
-    "none", "sd", "damp-pr", "damp-w", "bfgs", "pr", "w",
-})
-VALID_CELL_DOFREE = frozenset({
-    "all", "x", "y", "z", "xy", "xz", "yz", "xyz", "shape", "volume",
-    "2dxy", "2dshape",
-})
+VALID_CALCULATIONS = frozenset(
+    {
+        "scf",
+        "nscf",
+        "bands",
+        "relax",
+        "md",
+        "vc-relax",
+        "vc-md",
+    }
+)
+VALID_DIAGALIZATIONS = frozenset(
+    {
+        "david",
+        "cg",
+        "ppcg",
+        "paro",
+        "rmm-davidson",
+        "rmm-paro",
+    }
+)
+VALID_MIXING_MODES = frozenset(
+    {
+        "plain",
+        "tf",
+        "local-tf",
+    }
+)
+VALID_SMEARING = frozenset(
+    {
+        "gaussian",
+        "methfessel-paxton",
+        "mp",
+        "mv",
+        "fermi-dirac",
+        "fd",
+    }
+)
+VALID_OCCUPATIONS = frozenset(
+    {
+        "smearing",
+        "tetrahedra",
+        "tetrahedra_lin",
+        "tetrahedra_opt",
+        "fixed",
+        "from_input",
+    }
+)
+VALID_ION_DYNAMICS = frozenset(
+    {
+        "none",
+        "bfgs",
+        "damp",
+        "verlet",
+        "langevin",
+        "beeman",
+    }
+)
+VALID_CELL_DYNAMICS = frozenset(
+    {
+        "none",
+        "sd",
+        "damp-pr",
+        "damp-w",
+        "bfgs",
+        "pr",
+        "w",
+    }
+)
+VALID_CELL_DOFREE = frozenset(
+    {
+        "all",
+        "x",
+        "y",
+        "z",
+        "xy",
+        "xz",
+        "yz",
+        "xyz",
+        "shape",
+        "volume",
+        "2dxy",
+        "2dshape",
+    }
+)
 
 #: Keyword -> (valid values, rule code for invalid value)
 VALUE_CONSTRAINTS: dict[str, tuple[frozenset[str], str]] = {
@@ -214,53 +390,77 @@ class LintProvider:
 
         control = namelists.get("&CONTROL", {})
         if not control:
-            diagnostics.append(self._make(
-                line=0, char=0, length=0,
-                message="Missing required namelist &CONTROL.",
-                severity=DiagnosticSeverity.Error,
-                code=RULE_MISSING_REQUIRED_SECTION,
-            ))
+            diagnostics.append(
+                self._make(
+                    line=0,
+                    char=0,
+                    length=0,
+                    message="Missing required namelist &CONTROL.",
+                    severity=DiagnosticSeverity.Error,
+                    code=RULE_MISSING_REQUIRED_SECTION,
+                )
+            )
         elif "calculation" not in control:
-            diagnostics.append(self._make(
-                line=0, char=0, length=0,
-                message="Missing required parameter 'calculation' in &CONTROL.",
-                severity=DiagnosticSeverity.Error,
-                code=RULE_MISSING_CONTROL_CALC,
-            ))
+            diagnostics.append(
+                self._make(
+                    line=0,
+                    char=0,
+                    length=0,
+                    message="Missing required parameter 'calculation' in &CONTROL.",
+                    severity=DiagnosticSeverity.Error,
+                    code=RULE_MISSING_CONTROL_CALC,
+                )
+            )
 
         system = namelists.get("&SYSTEM", {})
         if not system:
-            diagnostics.append(self._make(
-                line=0, char=0, length=0,
-                message="Missing required namelist &SYSTEM.",
-                severity=DiagnosticSeverity.Error,
-                code=RULE_MISSING_REQUIRED_SECTION,
-            ))
+            diagnostics.append(
+                self._make(
+                    line=0,
+                    char=0,
+                    length=0,
+                    message="Missing required namelist &SYSTEM.",
+                    severity=DiagnosticSeverity.Error,
+                    code=RULE_MISSING_REQUIRED_SECTION,
+                )
+            )
         elif "ecutwfc" not in system and "nat" not in system:
-            diagnostics.append(self._make(
-                line=0, char=0, length=0,
-                message="Missing required parameter 'ecutwfc' in &SYSTEM.",
-                severity=DiagnosticSeverity.Error,
-                code=RULE_MISSING_SYSTEM_ECUTWFC,
-            ))
+            diagnostics.append(
+                self._make(
+                    line=0,
+                    char=0,
+                    length=0,
+                    message="Missing required parameter 'ecutwfc' in &SYSTEM.",
+                    severity=DiagnosticSeverity.Error,
+                    code=RULE_MISSING_SYSTEM_ECUTWFC,
+                )
+            )
 
         has_species = "ATOMIC_SPECIES" in parsed.cards
         has_positions = "ATOMIC_POSITIONS" in parsed.cards
         if system and "nat" in system:
             if not has_species:
-                diagnostics.append(self._make(
-                    line=0, char=0, length=0,
-                    message="Missing required card ATOMIC_SPECIES (nat is set).",
-                    severity=DiagnosticSeverity.Error,
-                    code=RULE_MISSING_ATOMIC_SPECIES,
-                ))
+                diagnostics.append(
+                    self._make(
+                        line=0,
+                        char=0,
+                        length=0,
+                        message="Missing required card ATOMIC_SPECIES (nat is set).",
+                        severity=DiagnosticSeverity.Error,
+                        code=RULE_MISSING_ATOMIC_SPECIES,
+                    )
+                )
             if not has_positions:
-                diagnostics.append(self._make(
-                    line=0, char=0, length=0,
-                    message="Missing required card ATOMIC_POSITIONS (nat is set).",
-                    severity=DiagnosticSeverity.Error,
-                    code=RULE_MISSING_ATOMIC_POSITIONS,
-                ))
+                diagnostics.append(
+                    self._make(
+                        line=0,
+                        char=0,
+                        length=0,
+                        message="Missing required card ATOMIC_POSITIONS (nat is set).",
+                        severity=DiagnosticSeverity.Error,
+                        code=RULE_MISSING_ATOMIC_POSITIONS,
+                    )
+                )
 
     def _check_unknown_namelists(
         self,
@@ -270,12 +470,16 @@ class LintProvider:
         """Flag namelists outside the QE grammar."""
         for name, line_num in parsed.namelist_lines.items():
             if name not in VALID_NAMELISTS:
-                diagnostics.append(self._make(
-                    line=line_num, char=0, length=len(name),
-                    message=f"Unknown namelist {name}.",
-                    severity=DiagnosticSeverity.Error,
-                    code=RULE_UNKNOWN_NAMELIST,
-                ))
+                diagnostics.append(
+                    self._make(
+                        line=line_num,
+                        char=0,
+                        length=len(name),
+                        message=f"Unknown namelist {name}.",
+                        severity=DiagnosticSeverity.Error,
+                        code=RULE_UNKNOWN_NAMELIST,
+                    )
+                )
 
     def _check_unknown_keywords(
         self,
@@ -289,14 +493,16 @@ class LintProvider:
                 continue
             for param_name, param in params.items():
                 if param_name not in known:
-                    diagnostics.append(self._make(
-                        line=param.line,
-                        char=param.character,
-                        length=len(param_name),
-                        message=f"Unknown keyword '{param_name}' in {namelist_name}.",
-                        severity=DiagnosticSeverity.Warning,
-                        code=RULE_UNKNOWN_KEYWORD,
-                    ))
+                    diagnostics.append(
+                        self._make(
+                            line=param.line,
+                            char=param.character,
+                            length=len(param_name),
+                            message=f"Unknown keyword '{param_name}' in {namelist_name}.",
+                            severity=DiagnosticSeverity.Warning,
+                            code=RULE_UNKNOWN_KEYWORD,
+                        )
+                    )
 
     def _check_invalid_values(
         self,
@@ -315,17 +521,18 @@ class LintProvider:
                     raw_display = _strip_quotes(param.value)
                     valid_str = ", ".join(sorted(valid_values))
                     msg = (
-                        f"Invalid value '{raw_display}' for '{param_name}'. "
-                        f"Valid: {valid_str}."
+                        f"Invalid value '{raw_display}' for '{param_name}'. " f"Valid: {valid_str}."
                     )
-                    diagnostics.append(self._make(
-                        line=param.line,
-                        char=param.character,
-                        length=len(param_name),
-                        message=msg,
-                        severity=DiagnosticSeverity.Error,
-                        code=rule_code,
-                    ))
+                    diagnostics.append(
+                        self._make(
+                            line=param.line,
+                            char=param.character,
+                            length=len(param_name),
+                            message=msg,
+                            severity=DiagnosticSeverity.Error,
+                            code=rule_code,
+                        )
+                    )
 
     def _check_deprecated_keywords(
         self,
@@ -337,14 +544,16 @@ class LintProvider:
             for param_name, param in params.items():
                 hint = DEPRECATED_KEYWORDS.get(param_name)
                 if hint is not None:
-                    diagnostics.append(self._make(
-                        line=param.line,
-                        char=param.character,
-                        length=len(param_name),
-                        message=f"Deprecated keyword '{param_name}'. {hint}",
-                        severity=DiagnosticSeverity.Warning,
-                        code=RULE_DEPRECATED_KEYWORD,
-                    ))
+                    diagnostics.append(
+                        self._make(
+                            line=param.line,
+                            char=param.character,
+                            length=len(param_name),
+                            message=f"Deprecated keyword '{param_name}'. {hint}",
+                            severity=DiagnosticSeverity.Warning,
+                            code=RULE_DEPRECATED_KEYWORD,
+                        )
+                    )
 
     def _check_inconsistent_settings(
         self,
@@ -356,7 +565,6 @@ class LintProvider:
         system = parsed.namelists.get("&SYSTEM", {})
         ions = parsed.namelists.get("&IONS", {})
         cell = parsed.namelists.get("&CELL", {})
-        electrons = parsed.namelists.get("&ELECTRONS", {})
 
         calc_param = control.get("calculation")
         if calc_param is None:
@@ -365,20 +573,28 @@ class LintProvider:
         calc = normalize_value(calc_param.value)
 
         if calc in ("relax", "vc-relax") and not ions:
-            diagnostics.append(self._make(
-                line=0, char=0, length=0,
-                message=f"&IONS namelist is recommended for calculation='{calc}'.",
-                severity=DiagnosticSeverity.Warning,
-                code=RULE_INCONSISTENT_SETTINGS,
-            ))
+            diagnostics.append(
+                self._make(
+                    line=0,
+                    char=0,
+                    length=0,
+                    message=f"&IONS namelist is recommended for calculation='{calc}'.",
+                    severity=DiagnosticSeverity.Warning,
+                    code=RULE_INCONSISTENT_SETTINGS,
+                )
+            )
 
         if calc in ("vc-relax", "vc-md") and not cell:
-            diagnostics.append(self._make(
-                line=0, char=0, length=0,
-                message=f"&CELL namelist is required for calculation='{calc}'.",
-                severity=DiagnosticSeverity.Error,
-                code=RULE_INCONSISTENT_SETTINGS,
-            ))
+            diagnostics.append(
+                self._make(
+                    line=0,
+                    char=0,
+                    length=0,
+                    message=f"&CELL namelist is required for calculation='{calc}'.",
+                    severity=DiagnosticSeverity.Error,
+                    code=RULE_INCONSISTENT_SETTINGS,
+                )
+            )
 
         nspin_param = system.get("nspin")
         if nspin_param is not None:
@@ -389,32 +605,39 @@ class LintProvider:
                 noncolin_param = system.get("noncolin")
                 if noncolin_param is not None:
                     has_nc_val = normalize_value(noncolin_param.value) in (
-                        ".true.", "true", "t",
+                        ".true.",
+                        "true",
+                        "t",
                     )
                 if not has_mag and not has_nc_val:
-                    diagnostics.append(self._make(
-                        line=nspin_param.line,
-                        char=nspin_param.character,
-                        length=len("nspin"),
-                        message=(
-                            "nspin > 1 but no starting_magnetization or "
-                            "noncolin = .true. set in &SYSTEM."
-                        ),
-                        severity=DiagnosticSeverity.Warning,
-                        code=RULE_INCONSISTENT_SETTINGS,
-                    ))
+                    diagnostics.append(
+                        self._make(
+                            line=nspin_param.line,
+                            char=nspin_param.character,
+                            length=len("nspin"),
+                            message=(
+                                "nspin > 1 but no starting_magnetization or "
+                                "noncolin = .true. set in &SYSTEM."
+                            ),
+                            severity=DiagnosticSeverity.Warning,
+                            code=RULE_INCONSISTENT_SETTINGS,
+                        )
+                    )
 
         if calc in ("nscf", "bands"):
             if "nbnd" not in system:
-                diagnostics.append(self._make(
-                    line=0, char=0, length=0,
-                    message=(
-                        f"calculation='{calc}' usually requires explicit "
-                        "nbnd in &SYSTEM."
-                    ),
-                    severity=DiagnosticSeverity.Warning,
-                    code=RULE_INCONSISTENT_SETTINGS,
-                ))
+                diagnostics.append(
+                    self._make(
+                        line=0,
+                        char=0,
+                        length=0,
+                        message=(
+                            f"calculation='{calc}' usually requires explicit " "nbnd in &SYSTEM."
+                        ),
+                        severity=DiagnosticSeverity.Warning,
+                        code=RULE_INCONSISTENT_SETTINGS,
+                    )
+                )
 
     def _check_orphan_parameters(
         self,
@@ -440,14 +663,16 @@ class LintProvider:
             if not in_namelist:
                 for match in ASSIGNMENT_RE.finditer(line):
                     name = match.group(1)
-                    diagnostics.append(self._make(
-                        line=line_number,
-                        char=match.start(1),
-                        length=len(name),
-                        message=f"Parameter '{name}' is outside any namelist.",
-                        severity=DiagnosticSeverity.Warning,
-                        code=RULE_ORPHAN_PARAMETER,
-                    ))
+                    diagnostics.append(
+                        self._make(
+                            line=line_number,
+                            char=match.start(1),
+                            length=len(name),
+                            message=f"Parameter '{name}' is outside any namelist.",
+                            severity=DiagnosticSeverity.Warning,
+                            code=RULE_ORPHAN_PARAMETER,
+                        )
+                    )
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/qe_lsp/features/navigation.py
+++ b/src/qe_lsp/features/navigation.py
@@ -2,7 +2,7 @@
 
 import re
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 from lsprotocol import types
 
@@ -47,7 +47,11 @@ def build_symbol_index(text: str) -> SymbolIndex:
         char = line.upper().find(name.upper())
         if char < 0:
             char = 0
-        index.add(SymbolInfo(name=name, kind="namelist", line=line_number, character=char, length=len(name)))
+        index.add(
+            SymbolInfo(
+                name=name, kind="namelist", line=line_number, character=char, length=len(name)
+            )
+        )
 
     # Index parameters inside namelists
     for namelist_name, parameters in parsed.namelists.items():
@@ -64,13 +68,13 @@ def build_symbol_index(text: str) -> SymbolIndex:
 
     # Index cards
     for card_name, card_header in parsed.card_headers.items():
-        line_number = _find_card_line(lines, card_name)
-        if line_number is not None:
+        card_line_number = _find_card_line(lines, card_name)
+        if card_line_number is not None:
             index.add(
                 SymbolInfo(
                     name=card_name,
                     kind="card",
-                    line=line_number,
+                    line=card_line_number,
                     character=0,
                     length=len(card_name),
                 )
@@ -121,7 +125,9 @@ def _get_uri(params: object) -> str:
 # ---------------------------------------------------------------------------
 
 
-def get_definition(text: str, line_number: int, character: int, uri: str) -> Optional[types.Location]:
+def get_definition(
+    text: str, line_number: int, character: int, uri: str
+) -> Optional[types.Location]:
     """Return the definition location for the symbol at the given position.
 
     Handles:
@@ -239,7 +245,9 @@ def get_references(
                 uri=uri,
                 range=types.Range(
                     start=types.Position(line=symbol.line, character=symbol.character),
-                    end=types.Position(line=symbol.line, character=symbol.character + symbol.length),
+                    end=types.Position(
+                        line=symbol.line, character=symbol.character + symbol.length
+                    ),
                 ),
             )
         )
@@ -372,11 +380,15 @@ def _namelist_parameter_symbols(
                 kind=types.SymbolKind.Field,
                 range=types.Range(
                     start=types.Position(line=parameter.line, character=parameter.character),
-                    end=types.Position(line=parameter.line, character=parameter.character + len(param_name)),
+                    end=types.Position(
+                        line=parameter.line, character=parameter.character + len(param_name)
+                    ),
                 ),
                 selection_range=types.Range(
                     start=types.Position(line=parameter.line, character=parameter.character),
-                    end=types.Position(line=parameter.line, character=parameter.character + len(param_name)),
+                    end=types.Position(
+                        line=parameter.line, character=parameter.character + len(param_name)
+                    ),
                 ),
             )
         )

--- a/src/qe_lsp/features/regression.py
+++ b/src/qe_lsp/features/regression.py
@@ -16,11 +16,13 @@ class GoldenFixture:
     expected_diagnostics: List[Dict[str, Any]] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
 
+
 @dataclass
 class RegressionResult:
     name: str
     passed: bool
     mismatches: List[str] = field(default_factory=list)
+
 
 class RegressionHarness:
     def __init__(self) -> None:
@@ -32,15 +34,24 @@ class RegressionHarness:
     def run_fixture(self, name: str) -> RegressionResult:
         fixture = self._fixtures.get(name)
         if fixture is None:
-            return RegressionResult(name=name, passed=False, mismatches=[f"Fixture '{name}' not found"])
+            return RegressionResult(
+                name=name, passed=False, mismatches=[f"Fixture '{name}' not found"]
+            )
         return RegressionResult(name=name, passed=True)
 
     def run_all(self) -> List[RegressionResult]:
         return [self.run_fixture(n) for n in self._fixtures]
 
-    def snapshot_fixture(self, name: str, source: str, diagnostics: Optional[List[Diagnostic]] = None) -> str:
-        diag_dicts = [{"line": d.range.start.line, "message": d.message, "code": d.code} for d in (diagnostics or [])]
-        return json.dumps({"name": name, "input_source": source, "expected_diagnostics": diag_dicts}, indent=2)
+    def snapshot_fixture(
+        self, name: str, source: str, diagnostics: Optional[List[Diagnostic]] = None
+    ) -> str:
+        diag_dicts = [
+            {"line": d.range.start.line, "message": d.message, "code": d.code}
+            for d in (diagnostics or [])
+        ]
+        return json.dumps(
+            {"name": name, "input_source": source, "expected_diagnostics": diag_dicts}, indent=2
+        )
 
     @property
     def fixture_count(self) -> int:

--- a/src/qe_lsp/features/rename.py
+++ b/src/qe_lsp/features/rename.py
@@ -9,7 +9,7 @@ editor can present actionable feedback to the user.
 from __future__ import annotations
 
 import re
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional
 
 from lsprotocol.types import (
     Position,
@@ -27,14 +27,25 @@ from ..text import strip_inline_comment
 
 #: Namelist headers that the user should rename through code actions,
 #: not free-form rename.
-_NAMELIST_HEADERS = frozenset({
-    "&CONTROL", "&SYSTEM", "&ELECTRONS", "&IONS", "&CELL",
-})
+_NAMELIST_HEADERS = frozenset(
+    {
+        "&CONTROL",
+        "&SYSTEM",
+        "&ELECTRONS",
+        "&IONS",
+        "&CELL",
+    }
+)
 
 #: Card headers that are structural keywords.
-_CARD_HEADERS = frozenset({
-    "ATOMIC_SPECIES", "ATOMIC_POSITIONS", "K_POINTS", "CELL_PARAMETERS",
-})
+_CARD_HEADERS = frozenset(
+    {
+        "ATOMIC_SPECIES",
+        "ATOMIC_POSITIONS",
+        "K_POINTS",
+        "CELL_PARAMETERS",
+    }
+)
 
 
 # ------------------------------------------------------------------
@@ -121,7 +132,6 @@ class RenameProvider:
             # Strip only comments, preserve leading whitespace for correct positions
             comment_stripped = raw_line.split("!", 1)[0]
             for match in ASSIGNMENT_RE.finditer(comment_stripped):
-                name = match.group(1)
                 if match.start(1) <= character <= match.end(1):
                     return Range(
                         start=Position(line=line, character=match.start(1)),
@@ -167,7 +177,6 @@ class RenameProvider:
         if line < 0 or line >= len(lines):
             return None
 
-        raw_line = lines[line]
         word = _word_at(text, line, character)
         if not word:
             return None
@@ -244,12 +253,8 @@ class RenameProvider:
                         edits.append(
                             TextEdit(
                                 range=Range(
-                                    start=Position(
-                                        line=i, character=match.start(1)
-                                    ),
-                                    end=Position(
-                                        line=i, character=match.end(1)
-                                    ),
+                                    start=Position(line=i, character=match.start(1)),
+                                    end=Position(line=i, character=match.end(1)),
                                 ),
                                 new_text=new_name,
                             )

--- a/src/qe_lsp/features/test_runner.py
+++ b/src/qe_lsp/features/test_runner.py
@@ -21,6 +21,7 @@ from lsprotocol.types import Diagnostic, DiagnosticSeverity, Position, Range
 @dataclass
 class TestRunnerConfig:
     """Configuration for the QE test runner."""
+
     executable: str = ""
     timeout: float = 30.0
     enabled: bool = False
@@ -75,15 +76,31 @@ def parse_solver_output(raw: str) -> SolverOutput:
 def solver_output_to_diagnostics(output: SolverOutput) -> List[Diagnostic]:
     diagnostics: List[Diagnostic] = []
     for err in output.errors:
-        diagnostics.append(Diagnostic(
-            range=Range(start=Position(line=err["line"], character=0), end=Position(line=err["line"], character=999)),
-            message=err["message"], severity=DiagnosticSeverity.Error,
-            source="qe-test-runner", code="QE9001"))
+        diagnostics.append(
+            Diagnostic(
+                range=Range(
+                    start=Position(line=err["line"], character=0),
+                    end=Position(line=err["line"], character=999),
+                ),
+                message=err["message"],
+                severity=DiagnosticSeverity.Error,
+                source="qe-test-runner",
+                code="QE9001",
+            )
+        )
     for warn in output.warnings:
-        diagnostics.append(Diagnostic(
-            range=Range(start=Position(line=warn["line"], character=0), end=Position(line=warn["line"], character=999)),
-            message=warn["message"], severity=DiagnosticSeverity.Warning,
-            source="qe-test-runner", code="QE9002"))
+        diagnostics.append(
+            Diagnostic(
+                range=Range(
+                    start=Position(line=warn["line"], character=0),
+                    end=Position(line=warn["line"], character=999),
+                ),
+                message=warn["message"],
+                severity=DiagnosticSeverity.Warning,
+                source="qe-test-runner",
+                code="QE9002",
+            )
+        )
     return diagnostics
 
 
@@ -104,35 +121,70 @@ class TestRunnerProvider:
 
     def run_validation(self, source: str) -> List[Diagnostic]:
         if not self._config.enabled:
-            return [Diagnostic(range=Range(start=Position(0, 0), end=Position(0, 0)),
-                message="QE test runner is not enabled. Configure the executable path to enable.",
-                severity=DiagnosticSeverity.Information, source="qe-test-runner", code="QE9000")]
+            return [
+                Diagnostic(
+                    range=Range(start=Position(0, 0), end=Position(0, 0)),
+                    message="QE test runner is not enabled. Configure the executable path to enable.",
+                    severity=DiagnosticSeverity.Information,
+                    source="qe-test-runner",
+                    code="QE9000",
+                )
+            ]
         if not self._config.executable:
-            return [Diagnostic(range=Range(start=Position(0, 0), end=Position(0, 0)),
-                message="QE executable path is not configured.",
-                severity=DiagnosticSeverity.Warning, source="qe-test-runner", code="QE9000")]
+            return [
+                Diagnostic(
+                    range=Range(start=Position(0, 0), end=Position(0, 0)),
+                    message="QE executable path is not configured.",
+                    severity=DiagnosticSeverity.Warning,
+                    source="qe-test-runner",
+                    code="QE9000",
+                )
+            ]
         import shutil
+
         if not shutil.which(self._config.executable):
-            return [Diagnostic(range=Range(start=Position(0, 0), end=Position(0, 0)),
-                message=f"QE executable not found: {self._config.executable}",
-                severity=DiagnosticSeverity.Error, source="qe-test-runner", code="QE9000")]
+            return [
+                Diagnostic(
+                    range=Range(start=Position(0, 0), end=Position(0, 0)),
+                    message=f"QE executable not found: {self._config.executable}",
+                    severity=DiagnosticSeverity.Error,
+                    source="qe-test-runner",
+                    code="QE9000",
+                )
+            ]
         try:
             with tempfile.NamedTemporaryFile(mode="w", suffix=".in", delete=False) as f:
                 f.write(source)
                 temp_path = f.name
-            result = subprocess.run([self._config.executable, "-input", temp_path],
-                capture_output=True, text=True, timeout=self._config.timeout)
+            result = subprocess.run(
+                [self._config.executable, "-input", temp_path],
+                capture_output=True,
+                text=True,
+                timeout=self._config.timeout,
+            )
             raw_output = result.stdout + "\n" + result.stderr
             output = parse_solver_output(raw_output)
             return solver_output_to_diagnostics(output)
         except subprocess.TimeoutExpired:
-            return [Diagnostic(range=Range(start=Position(0, 0), end=Position(0, 0)),
-                message=f"QE validation timed out after {self._config.timeout}s.",
-                severity=DiagnosticSeverity.Warning, source="qe-test-runner", code="QE9003")]
+            return [
+                Diagnostic(
+                    range=Range(start=Position(0, 0), end=Position(0, 0)),
+                    message=f"QE validation timed out after {self._config.timeout}s.",
+                    severity=DiagnosticSeverity.Warning,
+                    source="qe-test-runner",
+                    code="QE9003",
+                )
+            ]
         except FileNotFoundError:
-            return [Diagnostic(range=Range(start=Position(0, 0), end=Position(0, 0)),
-                message=f"QE executable not found: {self._config.executable}",
-                severity=DiagnosticSeverity.Error, source="qe-test-runner", code="QE9000")]
+            return [
+                Diagnostic(
+                    range=Range(start=Position(0, 0), end=Position(0, 0)),
+                    message=f"QE executable not found: {self._config.executable}",
+                    severity=DiagnosticSeverity.Error,
+                    source="qe-test-runner",
+                    code="QE9000",
+                )
+            ]
         finally:
             try:
                 Path(temp_path).unlink()
@@ -144,6 +196,11 @@ class TestRunnerProvider:
         return solver_output_to_diagnostics(output)
 
     def snapshot_config(self) -> str:
-        return json.dumps({"enabled": self._config.enabled,
-            "executable": self._config.executable or "(not configured)",
-            "timeout": self._config.timeout}, indent=2)
+        return json.dumps(
+            {
+                "enabled": self._config.enabled,
+                "executable": self._config.executable or "(not configured)",
+                "timeout": self._config.timeout,
+            },
+            indent=2,
+        )

--- a/src/qe_lsp/features/typecheck.py
+++ b/src/qe_lsp/features/typecheck.py
@@ -11,7 +11,6 @@ incrementally extended as coverage grows without breaking existing checks.
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from lsprotocol.types import (
@@ -70,9 +69,17 @@ KEYWORD_SCHEMA: dict[str, dict[str, Any]] = {
     # &CONTROL
     "calculation": {
         "type": TYPE_STRING,
-        "enum": frozenset({
-            "scf", "nscf", "bands", "relax", "md", "vc-relax", "vc-md",
-        }),
+        "enum": frozenset(
+            {
+                "scf",
+                "nscf",
+                "bands",
+                "relax",
+                "md",
+                "vc-relax",
+                "vc-md",
+            }
+        ),
     },
     "title": {"type": TYPE_STRING},
     "verbosity": {"type": TYPE_STRING, "enum": frozenset({"high", "low", "default", "xml"})},
@@ -125,18 +132,30 @@ KEYWORD_SCHEMA: dict[str, dict[str, Any]] = {
     "ecutrho": {"type": TYPE_FLOAT, "min": 0, "units": ENERGY_UNITS},
     "occupations": {
         "type": TYPE_STRING,
-        "enum": frozenset({
-            "smearing", "tetrahedra", "tetrahedra_lin",
-            "tetrahedra_opt", "fixed", "from_input",
-        }),
+        "enum": frozenset(
+            {
+                "smearing",
+                "tetrahedra",
+                "tetrahedra_lin",
+                "tetrahedra_opt",
+                "fixed",
+                "from_input",
+            }
+        ),
     },
     "degauss": {"type": TYPE_FLOAT, "min": 0, "units": ENERGY_UNITS},
     "smearing": {
         "type": TYPE_STRING,
-        "enum": frozenset({
-            "gaussian", "methfessel-paxton", "mp", "mv",
-            "fermi-dirac", "fd",
-        }),
+        "enum": frozenset(
+            {
+                "gaussian",
+                "methfessel-paxton",
+                "mp",
+                "mv",
+                "fermi-dirac",
+                "fd",
+            }
+        ),
     },
     "nspin": {"type": TYPE_INTEGER, "enum": frozenset({"1", "2", "4"})},
     "starting_magnetization": {"type": TYPE_FLOAT, "min": -1.0, "max": 1.0},
@@ -157,9 +176,16 @@ KEYWORD_SCHEMA: dict[str, dict[str, Any]] = {
     "scf_must_converge": {"type": TYPE_BOOLEAN},
     "diagonalization": {
         "type": TYPE_STRING,
-        "enum": frozenset({
-            "david", "cg", "ppcg", "paro", "rmm-davidson", "rmm-paro",
-        }),
+        "enum": frozenset(
+            {
+                "david",
+                "cg",
+                "ppcg",
+                "paro",
+                "rmm-davidson",
+                "rmm-paro",
+            }
+        ),
     },
     "mixing_mode": {
         "type": TYPE_STRING,
@@ -188,15 +214,25 @@ KEYWORD_SCHEMA: dict[str, dict[str, Any]] = {
     "ion_positions": {"type": TYPE_STRING, "enum": frozenset({"default", "from_input"})},
     "pot_extrapolation": {
         "type": TYPE_STRING,
-        "enum": frozenset({
-            "none", "atomic", "first_order", "second_order",
-        }),
+        "enum": frozenset(
+            {
+                "none",
+                "atomic",
+                "first_order",
+                "second_order",
+            }
+        ),
     },
     "wfc_extrapolation": {
         "type": TYPE_STRING,
-        "enum": frozenset({
-            "none", "atomic", "first_order", "second_order",
-        }),
+        "enum": frozenset(
+            {
+                "none",
+                "atomic",
+                "first_order",
+                "second_order",
+            }
+        ),
     },
     "remove_rigid_rot": {"type": TYPE_BOOLEAN},
     "bfgs_ndim": {"type": TYPE_INTEGER, "min": 1},
@@ -218,10 +254,22 @@ KEYWORD_SCHEMA: dict[str, dict[str, Any]] = {
     "press_conv_thr": {"type": TYPE_FLOAT, "min": 0},
     "cell_dofree": {
         "type": TYPE_STRING,
-        "enum": frozenset({
-            "all", "x", "y", "z", "xy", "xz", "yz", "xyz",
-            "shape", "volume", "2dxy", "2dshape",
-        }),
+        "enum": frozenset(
+            {
+                "all",
+                "x",
+                "y",
+                "z",
+                "xy",
+                "xz",
+                "yz",
+                "xyz",
+                "shape",
+                "volume",
+                "2dxy",
+                "2dshape",
+            }
+        ),
     },
     "isotropic": {"type": TYPE_BOOLEAN},
     "fix_volume": {"type": TYPE_BOOLEAN},
@@ -299,7 +347,7 @@ def _extract_unit_from_line(
     eq_pos = raw_line.find("=")
     if eq_pos < 0:
         return None
-    rhs = raw_line[eq_pos + 1:].strip()
+    rhs = raw_line[eq_pos + 1 :].strip()
     # Strip surrounding quotes from the first token
     rhs = rhs.strip("'\"")
     parts = rhs.split()
@@ -386,31 +434,37 @@ class TypecheckProvider:
 
         if expected_type == TYPE_BOOLEAN:
             if not _is_boolean(param.value):
-                diagnostics.append(_make_diagnostic(
-                    param,
-                    f"Expected boolean for '{param.name}', got '{raw_value}'. "
-                    f"Use .true. or .false.",
-                    DiagnosticSeverity.Error,
-                    RULE_TYPE_MISMATCH,
-                ))
+                diagnostics.append(
+                    _make_diagnostic(
+                        param,
+                        f"Expected boolean for '{param.name}', got '{raw_value}'. "
+                        f"Use .true. or .false.",
+                        DiagnosticSeverity.Error,
+                        RULE_TYPE_MISMATCH,
+                    )
+                )
 
         elif expected_type == TYPE_INTEGER:
             if not _is_integer(param.value):
-                diagnostics.append(_make_diagnostic(
-                    param,
-                    f"Expected integer for '{param.name}', got '{raw_value}'.",
-                    DiagnosticSeverity.Error,
-                    RULE_TYPE_MISMATCH,
-                ))
+                diagnostics.append(
+                    _make_diagnostic(
+                        param,
+                        f"Expected integer for '{param.name}', got '{raw_value}'.",
+                        DiagnosticSeverity.Error,
+                        RULE_TYPE_MISMATCH,
+                    )
+                )
 
         elif expected_type == TYPE_FLOAT:
             if not _is_float(param.value):
-                diagnostics.append(_make_diagnostic(
-                    param,
-                    f"Expected numeric value for '{param.name}', got '{raw_value}'.",
-                    DiagnosticSeverity.Error,
-                    RULE_TYPE_MISMATCH,
-                ))
+                diagnostics.append(
+                    _make_diagnostic(
+                        param,
+                        f"Expected numeric value for '{param.name}', got '{raw_value}'.",
+                        DiagnosticSeverity.Error,
+                        RULE_TYPE_MISMATCH,
+                    )
+                )
 
         elif expected_type == TYPE_STRING:
             # Strings in QE are always valid; enum validation is separate.
@@ -418,12 +472,14 @@ class TypecheckProvider:
 
         elif expected_type == TYPE_PATH:
             if not raw_value:
-                diagnostics.append(_make_diagnostic(
-                    param,
-                    f"Expected file path for '{param.name}', got empty value.",
-                    DiagnosticSeverity.Error,
-                    RULE_TYPE_MISMATCH,
-                ))
+                diagnostics.append(
+                    _make_diagnostic(
+                        param,
+                        f"Expected file path for '{param.name}', got empty value.",
+                        DiagnosticSeverity.Error,
+                        RULE_TYPE_MISMATCH,
+                    )
+                )
 
     def _check_enum_values(
         self,
@@ -443,13 +499,15 @@ class TypecheckProvider:
                 if normalized not in valid_values:
                     raw_display = param.value.strip().strip("'\"")
                     valid_str = ", ".join(sorted(valid_values))
-                    diagnostics.append(_make_diagnostic(
-                        param,
-                        f"Invalid value '{raw_display}' for '{_param_name}'. "
-                        f"Valid: {valid_str}.",
-                        DiagnosticSeverity.Error,
-                        RULE_ENUM_INVALID,
-                    ))
+                    diagnostics.append(
+                        _make_diagnostic(
+                            param,
+                            f"Invalid value '{raw_display}' for '{_param_name}'. "
+                            f"Valid: {valid_str}.",
+                            DiagnosticSeverity.Error,
+                            RULE_ENUM_INVALID,
+                        )
+                    )
 
     def _check_units(
         self,
@@ -479,21 +537,25 @@ class TypecheckProvider:
                 if unit not in allowed_units:
                     valid_str = ", ".join(sorted(allowed_units))
                     if unit in ALL_KNOWN_UNITS:
-                        diagnostics.append(_make_diagnostic(
-                            param,
-                            f"Unit '{unit}' is not valid for '{_param_name}'. "
-                            f"Expected one of: {valid_str}.",
-                            DiagnosticSeverity.Error,
-                            RULE_UNIT_UNKNOWN,
-                        ))
+                        diagnostics.append(
+                            _make_diagnostic(
+                                param,
+                                f"Unit '{unit}' is not valid for '{_param_name}'. "
+                                f"Expected one of: {valid_str}.",
+                                DiagnosticSeverity.Error,
+                                RULE_UNIT_UNKNOWN,
+                            )
+                        )
                     else:
-                        diagnostics.append(_make_diagnostic(
-                            param,
-                            f"Unknown unit '{unit}' for '{_param_name}'. "
-                            f"Known units: {valid_str}.",
-                            DiagnosticSeverity.Error,
-                            RULE_UNIT_UNKNOWN,
-                        ))
+                        diagnostics.append(
+                            _make_diagnostic(
+                                param,
+                                f"Unknown unit '{unit}' for '{_param_name}'. "
+                                f"Known units: {valid_str}.",
+                                DiagnosticSeverity.Error,
+                                RULE_UNIT_UNKNOWN,
+                            )
+                        )
 
     def _check_numeric_ranges(
         self,
@@ -516,21 +578,25 @@ class TypecheckProvider:
                     continue
 
                 if min_val is not None and numeric_value < min_val:
-                    diagnostics.append(_make_diagnostic(
-                        param,
-                        f"Value {numeric_value} for '{_param_name}' is below "
-                        f"minimum {min_val}.",
-                        DiagnosticSeverity.Warning,
-                        RULE_NUMERIC_RANGE,
-                    ))
+                    diagnostics.append(
+                        _make_diagnostic(
+                            param,
+                            f"Value {numeric_value} for '{_param_name}' is below "
+                            f"minimum {min_val}.",
+                            DiagnosticSeverity.Warning,
+                            RULE_NUMERIC_RANGE,
+                        )
+                    )
                 if max_val is not None and numeric_value > max_val:
-                    diagnostics.append(_make_diagnostic(
-                        param,
-                        f"Value {numeric_value} for '{_param_name}' exceeds "
-                        f"maximum {max_val}.",
-                        DiagnosticSeverity.Warning,
-                        RULE_NUMERIC_RANGE,
-                    ))
+                    diagnostics.append(
+                        _make_diagnostic(
+                            param,
+                            f"Value {numeric_value} for '{_param_name}' exceeds "
+                            f"maximum {max_val}.",
+                            DiagnosticSeverity.Warning,
+                            RULE_NUMERIC_RANGE,
+                        )
+                    )
 
     def _check_required_sections(
         self,
@@ -546,12 +612,14 @@ class TypecheckProvider:
         if ibrav is not None:
             ibrav_val = normalize_value(ibrav.value)
             if ibrav_val == "0" and "CELL_PARAMETERS" not in parsed.cards:
-                diagnostics.append(_make_diagnostic(
-                    ibrav,
-                    "ibrav = 0 requires an explicit CELL_PARAMETERS card.",
-                    DiagnosticSeverity.Error,
-                    RULE_REQUIRED_SECTION_MISSING,
-                ))
+                diagnostics.append(
+                    _make_diagnostic(
+                        ibrav,
+                        "ibrav = 0 requires an explicit CELL_PARAMETERS card.",
+                        DiagnosticSeverity.Error,
+                        RULE_REQUIRED_SECTION_MISSING,
+                    )
+                )
 
         # Check nat requires ATOMIC_SPECIES and ATOMIC_POSITIONS
         nat = system.get("nat")
@@ -561,19 +629,23 @@ class TypecheckProvider:
                 nat_int = int(float(nat_val))
                 if nat_int > 0:
                     if "ATOMIC_SPECIES" not in parsed.cards:
-                        diagnostics.append(_make_diagnostic(
-                            nat,
-                            "nat is set but ATOMIC_SPECIES card is missing.",
-                            DiagnosticSeverity.Error,
-                            RULE_REQUIRED_SECTION_MISSING,
-                        ))
+                        diagnostics.append(
+                            _make_diagnostic(
+                                nat,
+                                "nat is set but ATOMIC_SPECIES card is missing.",
+                                DiagnosticSeverity.Error,
+                                RULE_REQUIRED_SECTION_MISSING,
+                            )
+                        )
                     if "ATOMIC_POSITIONS" not in parsed.cards:
-                        diagnostics.append(_make_diagnostic(
-                            nat,
-                            "nat is set but ATOMIC_POSITIONS card is missing.",
-                            DiagnosticSeverity.Error,
-                            RULE_REQUIRED_SECTION_MISSING,
-                        ))
+                        diagnostics.append(
+                            _make_diagnostic(
+                                nat,
+                                "nat is set but ATOMIC_POSITIONS card is missing.",
+                                DiagnosticSeverity.Error,
+                                RULE_REQUIRED_SECTION_MISSING,
+                            )
+                        )
             except (ValueError, OverflowError):
                 pass
 
@@ -582,12 +654,14 @@ class TypecheckProvider:
         if calc is not None:
             calc_val = normalize_value(calc.value)
             if calc_val in ("vc-relax", "vc-md") and "&CELL" not in parsed.namelists:
-                diagnostics.append(_make_diagnostic(
-                    calc,
-                    f"calculation = '{calc_val}' requires the &CELL namelist.",
-                    DiagnosticSeverity.Error,
-                    RULE_REQUIRED_SECTION_MISSING,
-                ))
+                diagnostics.append(
+                    _make_diagnostic(
+                        calc,
+                        f"calculation = '{calc_val}' requires the &CELL namelist.",
+                        DiagnosticSeverity.Error,
+                        RULE_REQUIRED_SECTION_MISSING,
+                    )
+                )
 
 
 # ------------------------------------------------------------------

--- a/src/qe_lsp/handlers/code_action.py
+++ b/src/qe_lsp/handlers/code_action.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from lsprotocol.types import CodeAction, CodeActionParams
+from lsprotocol.types import CodeAction
 
 from qe_lsp.features.code_actions import CodeActionProvider
 

--- a/src/qe_lsp/handlers/rename.py
+++ b/src/qe_lsp/handlers/rename.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from lsprotocol.types import (
-    Position,
     Range,
     WorkspaceEdit,
 )
@@ -75,7 +74,7 @@ def _get_document_text(params: Any) -> Optional[str]:
         try:
             from qe_lsp.server import server as _server
 
-            return _server.documents.get(uri, None)  # type: ignore[attr-defined]
+            return cast(Optional[str], _server.documents.get(uri, None))  # type: ignore[attr-defined]
         except (ImportError, AttributeError):
             pass
 
@@ -88,4 +87,4 @@ def _get_uri(params: Any) -> str:
         text_document = get_attr(params, "textDocument", None)
     if text_document is None:
         return ""
-    return get_attr(text_document, "uri", "")
+    return cast(str, get_attr(text_document, "uri", ""))

--- a/src/qe_lsp/server.py
+++ b/src/qe_lsp/server.py
@@ -83,7 +83,10 @@ def create_server(name: str = SERVER_NAME, version: str = __version__) -> Any:
         text = lsp_server.documents.get(uri, "")  # type: ignore[attr-defined]
         if not text:
             return []
-        return lsp_server.formatting_provider.format_document(text, params)  # type: ignore[attr-defined]
+        return cast(
+            list,
+            lsp_server.formatting_provider.format_document(text, params),  # type: ignore[attr-defined]
+        )
 
     @_register(lsp_server, TEXT_DOCUMENT_RANGE_FORMATTING)
     def range_formatting(params: DocumentRangeFormattingParams) -> list:
@@ -91,7 +94,10 @@ def create_server(name: str = SERVER_NAME, version: str = __version__) -> Any:
         text = lsp_server.documents.get(uri, "")  # type: ignore[attr-defined]
         if not text:
             return []
-        return lsp_server.formatting_provider.format_range(text, params)  # type: ignore[attr-defined]
+        return cast(
+            list,
+            lsp_server.formatting_provider.format_range(text, params),  # type: ignore[attr-defined]
+        )
 
     return lsp_server
 

--- a/tests/features/test_agent_api.py
+++ b/tests/features/test_agent_api.py
@@ -1,11 +1,13 @@
-import json, pytest
+import json
 from lsprotocol.types import Diagnostic, DiagnosticSeverity, Position, Range
 from qe_lsp.features.agent_api import AgentAPIProvider, AgentAPISnapshot
+
 
 class TestSnapshot:
     def test_to_json(self):
         s = AgentAPISnapshot(uri="test", diagnostics=[{"line": 0}])
         assert json.loads(s.to_json())["uri"] == "test"
+
 
 class TestProvider:
     def test_empty(self):
@@ -13,8 +15,15 @@ class TestProvider:
         assert snap.diagnostics == []
 
     def test_with_diagnostics(self):
-        diags = [Diagnostic(range=Range(start=Position(0, 0), end=Position(0, 0)),
-            message="err", severity=DiagnosticSeverity.Error, source="test", code="X1")]
+        diags = [
+            Diagnostic(
+                range=Range(start=Position(0, 0), end=Position(0, 0)),
+                message="err",
+                severity=DiagnosticSeverity.Error,
+                source="test",
+                code="X1",
+            )
+        ]
         snap = AgentAPIProvider().get_snapshot("test", diagnostics=diags)
         assert len(snap.diagnostics) == 1
 

--- a/tests/features/test_code_actions.py
+++ b/tests/features/test_code_actions.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import pytest
 
 from lsprotocol.types import (
+    CodeAction,
     Diagnostic,
     DiagnosticSeverity,
     Position,
     Range,
+    TextEdit,
 )
 
 from qe_lsp.features.code_actions import CodeActionProvider
@@ -33,6 +35,12 @@ from qe_lsp.validation import validate_qe_input
 def provider() -> CodeActionProvider:
     """Create a CodeActionProvider instance."""
     return CodeActionProvider()
+
+
+def _text_edits(action: CodeAction) -> list[TextEdit]:
+    assert action.edit is not None
+    assert action.edit.changes is not None
+    return list(action.edit.changes["document"])
 
 
 @pytest.fixture
@@ -107,7 +115,9 @@ class TestFixUnknownKeyword:
 
     def test_no_action_for_very_short_unknown(self, provider: CodeActionProvider) -> None:
         diag = _diag(
-            line=1, char=2, length=1,
+            line=1,
+            char=2,
+            length=1,
             message="Unknown keyword 'x' in &CONTROL.",
             code=RULE_UNKNOWN_KEYWORD,
         )
@@ -152,7 +162,7 @@ class TestFixDeprecatedKeyword:
         assert any("Remove deprecated" in a.title for a in actions)
 
         action = next(a for a in actions if "deprecated" in a.title.lower())
-        text_edits = action.edit.changes["document"]
+        text_edits = _text_edits(action)
         # Removing the line produces an empty new_text
         assert text_edits[0].new_text == ""
 
@@ -174,7 +184,7 @@ class TestFixDuplicateParameter:
         assert any("duplicate" in a.title.lower() for a in actions)
 
         action = next(a for a in actions if "duplicate" in a.title.lower())
-        text_edits = action.edit.changes["document"]
+        text_edits = _text_edits(action)
         assert text_edits[0].new_text == ""
 
 
@@ -195,7 +205,7 @@ class TestFixMixingBeta:
         assert any("0.7" in a.title for a in actions)
 
         action = next(a for a in actions if "0.7" in a.title)
-        text_edits = action.edit.changes["document"]
+        text_edits = _text_edits(action)
         assert text_edits[0].new_text == "0.7"
 
 
@@ -206,13 +216,7 @@ class TestFixMixingBeta:
 
 class TestFixEcutrhoRatio:
     def test_adjusts_ecutrho_to_ratio(self, provider: CodeActionProvider) -> None:
-        source = (
-            "&SYSTEM\n"
-            "ibrav = 1\n"
-            "ecutwfc = 60.0\n"
-            "ecutrho = 100.0\n"
-            "/\n"
-        )
+        source = "&SYSTEM\n" "ibrav = 1\n" "ecutwfc = 60.0\n" "ecutrho = 100.0\n" "/\n"
         diags = validate_qe_input(source)
         ratio_warnings = [d for d in diags if "ecutrho should normally" in d.message]
         assert len(ratio_warnings) >= 1
@@ -222,7 +226,7 @@ class TestFixEcutrhoRatio:
         assert any("ecutrho" in a.title.lower() for a in actions)
 
         action = next(a for a in actions if "ecutrho" in a.title.lower())
-        text_edits = action.edit.changes["document"]
+        text_edits = _text_edits(action)
         # Should set to 4x60 = 240.0
         assert "240.0" in text_edits[0].new_text
 
@@ -244,7 +248,7 @@ class TestFixOrphanParameter:
         assert any("orphan" in a.title.lower() for a in actions)
 
         action = next(a for a in actions if "orphan" in a.title.lower())
-        text_edits = action.edit.changes["document"]
+        text_edits = _text_edits(action)
         assert text_edits[0].new_text == ""
 
 
@@ -343,8 +347,7 @@ class TestFixInconsistentSettings:
         )
         diags = LintProvider().lint(source)
         inconsistent = [
-            d for d in diags
-            if d.code == RULE_INCONSISTENT_SETTINGS and "&IONS" in d.message
+            d for d in diags if d.code == RULE_INCONSISTENT_SETTINGS and "&IONS" in d.message
         ]
         assert len(inconsistent) >= 1
 
@@ -368,8 +371,7 @@ class TestFixInconsistentSettings:
         )
         diags = LintProvider().lint(source)
         cell_diags = [
-            d for d in diags
-            if d.code == RULE_INCONSISTENT_SETTINGS and "&CELL" in d.message
+            d for d in diags if d.code == RULE_INCONSISTENT_SETTINGS and "&CELL" in d.message
         ]
         assert len(cell_diags) >= 1
 
@@ -423,7 +425,9 @@ class TestEdgeCases:
 
     def test_no_actions_for_unrelated_diagnostic(self, provider: CodeActionProvider) -> None:
         diag = _diag(
-            line=0, char=0, length=5,
+            line=0,
+            char=0,
+            length=5,
             message="Some unrelated issue",
             code="QE-Z999",
         )
@@ -506,11 +510,6 @@ class TestIntegration:
         assert len(unknowns) >= 1
 
         actions = provider.get_code_actions(source, diags)
-        # Should have an action for the unknown keyword
-        keyword_actions = [
-            a for a in actions
-            if "typo_param" in a.title or "Replace" in a.title
-        ]
         # Typo correction may or may not find a close match for "typo_param"
         # but the action should be attempted
         assert isinstance(actions, list)

--- a/tests/features/test_diagnostic.py
+++ b/tests/features/test_diagnostic.py
@@ -1,12 +1,17 @@
 """Tests for the DiagnosticProvider live diagnostics snapshot."""
 
 import json
+from typing import TYPE_CHECKING
 
 import pytest
-try:
+
+if TYPE_CHECKING:
     from pygls.lsp.server import LanguageServer
-except ImportError:
-    from pygls.server import LanguageServer
+else:
+    try:
+        from pygls.lsp.server import LanguageServer
+    except ImportError:
+        from pygls.server import LanguageServer
 
 from qe_lsp.features.diagnostic import DiagnosticProvider
 
@@ -112,13 +117,7 @@ class TestSnapshot:
 
     def test_snapshot_deterministic_ordering(self, provider: DiagnosticProvider) -> None:
         """Two calls with the same text must produce the same output."""
-        text = (
-            "&SYSTEM\n"
-            "ibrav = 0\n"
-            "/\n"
-            "&CONTROL\n"
-            "calculation = 'scf'\n"
-        )
+        text = "&SYSTEM\n" "ibrav = 0\n" "/\n" "&CONTROL\n" "calculation = 'scf'\n"
         first = provider.snapshot(text)
         second = provider.snapshot(text)
         assert first == second

--- a/tests/features/test_formatting.py
+++ b/tests/features/test_formatting.py
@@ -1,5 +1,7 @@
 """Tests for the FormattingProvider document and range formatting."""
 
+from typing import TYPE_CHECKING
+
 import pytest
 from lsprotocol.types import (
     DocumentFormattingParams,
@@ -12,10 +14,13 @@ from lsprotocol.types import (
 
 from qe_lsp.features.formatting import FormattingProvider, get_formatting_provider
 
-try:
+if TYPE_CHECKING:
     from pygls.lsp.server import LanguageServer
-except ImportError:
-    from pygls.server import LanguageServer
+else:
+    try:
+        from pygls.lsp.server import LanguageServer
+    except ImportError:
+        from pygls.server import LanguageServer
 
 
 # ------------------------------------------------------------------
@@ -95,32 +100,44 @@ class TestProviderCreation:
 
 
 class TestFormatDocument:
-    def test_empty_returns_empty(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
+    def test_empty_returns_empty(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         assert provider.format_document("", fmt_params) == []
 
-    def test_already_formatted_returns_empty(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
+    def test_already_formatted_returns_empty(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         text = "&CONTROL\n  calculation = 'scf'\n/\n"
         assert provider.format_document(text, fmt_params) == []
 
-    def test_single_line_no_change(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
+    def test_single_line_no_change(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         text = "ATOMIC_SPECIES\n"
         edits = provider.format_document(text, fmt_params)
         # Single card header with no body — already fine
         assert edits == []
 
-    def test_namelist_indentation(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
+    def test_namelist_indentation(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         text = "&CONTROL\ncalculation = 'scf'\n/\n"
         edits = provider.format_document(text, fmt_params)
         assert len(edits) == 1
         assert "  calculation = 'scf'" in edits[0].new_text
 
-    def test_card_indentation(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
+    def test_card_indentation(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         text = "ATOMIC_SPECIES\nSi 28.086 Si.pbe.UPF\n"
         edits = provider.format_document(text, fmt_params)
         assert len(edits) == 1
         assert "  Si 28.086 Si.pbe.UPF" in edits[0].new_text
 
-    def test_nested_namelists_and_cards(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
+    def test_nested_namelists_and_cards(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         text = (
             "&CONTROL\n"
             "calculation = 'scf'\n"
@@ -142,21 +159,25 @@ class TestFormatDocument:
         assert "  Si 28.086 Si.pbe.UPF" in formatted
         assert "  Si 0.0 0.0 0.0" in formatted
 
-    def test_4_space_indent(self, provider: FormattingProvider, fmt_params_4: DocumentFormattingParams) -> None:
+    def test_4_space_indent(
+        self, provider: FormattingProvider, fmt_params_4: DocumentFormattingParams
+    ) -> None:
         text = "&CONTROL\ncalculation = 'scf'\n/\n"
         edits = provider.format_document(text, fmt_params_4)
         assert len(edits) == 1
         assert "    calculation = 'scf'" in edits[0].new_text
 
-    def test_tab_indent(self, provider: FormattingProvider, fmt_params_tabs: DocumentFormattingParams) -> None:
+    def test_tab_indent(
+        self, provider: FormattingProvider, fmt_params_tabs: DocumentFormattingParams
+    ) -> None:
         text = "&CONTROL\ncalculation = 'scf'\n/\n"
         edits = provider.format_document(text, fmt_params_tabs)
         assert len(edits) == 1
         assert "\tcalculation = 'scf'" in edits[0].new_text
 
-    def test_trailing_newline_preserved(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
-        text = "&CONTROL\ncalculation = 'scf'\n/\n"
-        edits = provider.format_document(text, fmt_params)
+    def test_trailing_newline_preserved(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         # Already formatted — no edits
         # Let's use unformatted version
         text2 = "&CONTROL\ncalculation = 'scf'\n/\n"
@@ -164,7 +185,9 @@ class TestFormatDocument:
         if edits2:
             assert edits2[0].new_text.endswith("\n")
 
-    def test_idempotent(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
+    def test_idempotent(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         """Formatting the output of formatting again must produce no edits."""
         text = "&CONTROL\ncalculation = 'scf'\n/\n"
         first_edits = provider.format_document(text, fmt_params)
@@ -175,19 +198,25 @@ class TestFormatDocument:
 
 
 class TestFormatDocumentComments:
-    def test_comment_preserved(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
+    def test_comment_preserved(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         text = "! This is a comment\n&CONTROL\ncalculation = 'scf'\n/\n"
         edits = provider.format_document(text, fmt_params)
         assert len(edits) == 1
         assert "! This is a comment" in edits[0].new_text
 
-    def test_inline_comment_preserved(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
+    def test_inline_comment_preserved(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         text = "&CONTROL\ncalculation = 'scf' ! SCF run\n/\n"
         edits = provider.format_document(text, fmt_params)
         assert len(edits) == 1
         assert "! SCF run" in edits[0].new_text
 
-    def test_blank_lines_preserved(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
+    def test_blank_lines_preserved(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         text = "&CONTROL\n\ncalculation = 'scf'\n/\n"
         edits = provider.format_document(text, fmt_params)
         assert len(edits) == 1
@@ -197,19 +226,25 @@ class TestFormatDocumentComments:
 
 
 class TestFormatDocumentMalformed:
-    def test_unclosed_namelist(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
+    def test_unclosed_namelist(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         text = "&CONTROL\ncalculation = 'scf'\n"
         edits = provider.format_document(text, fmt_params)
         assert len(edits) == 1
         assert "  calculation = 'scf'" in edits[0].new_text
 
-    def test_stray_slash(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
+    def test_stray_slash(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         text = "/\n"
         edits = provider.format_document(text, fmt_params)
         # Slash without a namelist — should still format without error
         assert isinstance(edits, list)
 
-    def test_random_text(self, provider: FormattingProvider, fmt_params: DocumentFormattingParams) -> None:
+    def test_random_text(
+        self, provider: FormattingProvider, fmt_params: DocumentFormattingParams
+    ) -> None:
         text = "some random text\nmore random text\n"
         edits = provider.format_document(text, fmt_params)
         # Should not crash, and text without structure stays as-is
@@ -227,11 +262,7 @@ class TestFormatRange:
         assert provider.format_range("", params) == []
 
     def test_range_within_namelist(self, provider: FormattingProvider) -> None:
-        text = (
-            "&CONTROL\n"
-            "calculation = 'scf'\n"
-            "/\n"
-        )
+        text = "&CONTROL\n" "calculation = 'scf'\n" "/\n"
         # Format only line 1 (the assignment)
         params = _range_params(1, 1)
         edits = provider.format_range(text, params)
@@ -239,22 +270,14 @@ class TestFormatRange:
         assert "  calculation = 'scf'" in edits[0].new_text
 
     def test_range_includes_namelist_header(self, provider: FormattingProvider) -> None:
-        text = (
-            "&CONTROL\n"
-            "calculation = 'scf'\n"
-            "/\n"
-        )
+        text = "&CONTROL\n" "calculation = 'scf'\n" "/\n"
         # Format lines 0-2
         params = _range_params(0, 2)
         edits = provider.format_range(text, params)
         assert len(edits) == 1
 
     def test_already_formatted_range(self, provider: FormattingProvider) -> None:
-        text = (
-            "&CONTROL\n"
-            "  calculation = 'scf'\n"
-            "/\n"
-        )
+        text = "&CONTROL\n" "  calculation = 'scf'\n" "/\n"
         params = _range_params(1, 1)
         edits = provider.format_range(text, params)
         assert edits == []
@@ -268,14 +291,7 @@ class TestFormatRange:
 
     def test_range_preserves_surrounding_context(self, provider: FormattingProvider) -> None:
         """Range formatting must not affect lines outside the range."""
-        text = (
-            "&CONTROL\n"
-            "calculation = 'scf'\n"
-            "/\n"
-            "&SYSTEM\n"
-            "ibrav = 1\n"
-            "/\n"
-        )
+        text = "&CONTROL\n" "calculation = 'scf'\n" "/\n" "&SYSTEM\n" "ibrav = 1\n" "/\n"
         # Format only line 4 (ibrav = 1)
         params = _range_params(4, 4)
         edits = provider.format_range(text, params)

--- a/tests/features/test_lint.py
+++ b/tests/features/test_lint.py
@@ -39,13 +39,13 @@ class TestLintEmpty:
 
     def test_comment_only_no_diagnostics(self, provider: LintProvider) -> None:
         assert provider.lint("! just a comment\n") == []
+
     def test_empty_namelist_reports_missing_required(self, provider: LintProvider) -> None:
         """An empty &CONTROL is treated as missing; &SYSTEM is also missing."""
         text = "&CONTROL\n/\n"
         diagnostics = provider.lint(text)
         codes = [d.code for d in diagnostics]
         assert RULE_MISSING_REQUIRED_SECTION in codes
-
 
     def test_minimal_valid_input_no_errors(self, provider: LintProvider) -> None:
         """A well-formed minimal input produces zero errors."""
@@ -228,13 +228,11 @@ class TestLintSourceAndCode:
         text = "&FOOBAR\nx = 1\n/\n"
         diagnostics = provider.lint(text)
         assert diagnostics[0].code is not None
+        assert isinstance(diagnostics[0].code, str)
         assert diagnostics[0].code.startswith("QE-")
 
     def test_valid_enum_values_no_error(self, provider: LintProvider) -> None:
-        text = (
-            "&CONTROL\ncalculation = 'scf'\n/\n"
-            "&ELECTRONS\nmixing_mode = 'plain'\n/\n"
-        )
+        text = "&CONTROL\ncalculation = 'scf'\n/\n" "&ELECTRONS\nmixing_mode = 'plain'\n/\n"
         diagnostics = provider.lint(text)
         invalids = [d for d in diagnostics if d.code == RULE_INVALID_KEYWORD_VALUE]
         assert invalids == []
@@ -308,10 +306,7 @@ class TestSnapshot:
         assert error_items[0]["code"].startswith("QE-")
 
     def test_snapshot_deterministic_ordering(self, provider: LintProvider) -> None:
-        text = (
-            "&FOOBAR\nx = 1\n/\n"
-            "&CONTROL\ncalculation = 'bogus'\n/\n"
-        )
+        text = "&FOOBAR\nx = 1\n/\n" "&CONTROL\ncalculation = 'bogus'\n/\n"
         first = provider.snapshot(text)
         second = provider.snapshot(text)
         assert first == second

--- a/tests/features/test_navigation.py
+++ b/tests/features/test_navigation.py
@@ -1,6 +1,5 @@
 """Tests for navigation features: definition, hover, references, symbols."""
 
-import pytest
 from lsprotocol import types
 
 from qe_lsp.features.navigation import (
@@ -14,7 +13,6 @@ from qe_lsp.handlers.definition import definition
 from qe_lsp.handlers.document_symbol import document_symbol
 from qe_lsp.handlers.hover import hover
 from qe_lsp.handlers.references import references
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -45,6 +43,13 @@ Si 0.25 0.25 0.25
 K_POINTS {automatic}
 4 4 4 0 0 0
 """
+
+
+def _hover_value(result: types.Hover) -> str:
+    assert isinstance(result.contents, types.MarkupContent)
+    return result.contents.value
+
+
 # Line index:
 #  0: &CONTROL
 #  1:   calculation = 'scf'
@@ -216,25 +221,25 @@ class TestHover:
         result = get_hover(SAMPLE_INPUT, 0, 2)
         assert result is not None
         assert isinstance(result.contents, types.MarkupContent)
-        assert "&CONTROL" in result.contents.value
+        assert "&CONTROL" in _hover_value(result)
 
     def test_hover_card(self) -> None:
         # ATOMIC_SPECIES at line 16
         result = get_hover(SAMPLE_INPUT, 16, 2)
         assert result is not None
-        assert "ATOMIC_SPECIES" in result.contents.value
+        assert "ATOMIC_SPECIES" in _hover_value(result)
 
     def test_hover_parameter_ecutwfc(self) -> None:
         # ecutwfc at line 9
         result = get_hover(SAMPLE_INPUT, 9, 2)
         assert result is not None
-        assert "ecutwfc" in result.contents.value.lower()
+        assert "ecutwfc" in _hover_value(result).lower()
 
     def test_hover_mixing_beta(self) -> None:
         # mixing_beta at line 14
         result = get_hover(SAMPLE_INPUT, 14, 2)
         assert result is not None
-        assert "mixing_beta" in result.contents.value.lower()
+        assert "mixing_beta" in _hover_value(result).lower()
 
     def test_hover_unknown_returns_none(self) -> None:
         # whitespace-only position
@@ -247,7 +252,7 @@ class TestHover:
         result = hover(params)
         assert result is not None
         assert isinstance(result, types.Hover)
-        assert "ecutwfc" in result.contents.value.lower()
+        assert "ecutwfc" in _hover_value(result).lower()
 
     def test_hover_handler_empty(self) -> None:
         result = hover(Params("", line=0, character=0))
@@ -257,25 +262,25 @@ class TestHover:
         # ion_dynamics at line 10 in MULTI_NAMELIST_INPUT
         result = get_hover(MULTI_NAMELIST_INPUT, 10, 2)
         assert result is not None
-        assert "ion_dynamics" in result.contents.value.lower()
+        assert "ion_dynamics" in _hover_value(result).lower()
 
     def test_hover_cell_dynamics(self) -> None:
         # cell_dynamics at line 13 in MULTI_NAMELIST_INPUT
         result = get_hover(MULTI_NAMELIST_INPUT, 13, 2)
         assert result is not None
-        assert "cell_dynamics" in result.contents.value.lower()
+        assert "cell_dynamics" in _hover_value(result).lower()
 
     def test_hover_system_parameter(self) -> None:
         # ibrav at line 5
         result = get_hover(SAMPLE_INPUT, 5, 2)
         assert result is not None
-        assert "ibrav" in result.contents.value.lower()
+        assert "ibrav" in _hover_value(result).lower()
 
     def test_hover_conv_thr(self) -> None:
         # conv_thr at line 13
         result = get_hover(SAMPLE_INPUT, 13, 2)
         assert result is not None
-        assert "conv_thr" in result.contents.value.lower()
+        assert "conv_thr" in _hover_value(result).lower()
 
 
 # ===========================================================================

--- a/tests/features/test_regression.py
+++ b/tests/features/test_regression.py
@@ -1,6 +1,6 @@
-import json, pytest
-from lsprotocol.types import Diagnostic, DiagnosticSeverity, Position, Range
-from qe_lsp.features.regression import GoldenFixture, RegressionHarness, RegressionResult
+import json
+from qe_lsp.features.regression import GoldenFixture, RegressionHarness
+
 
 class TestHarness:
     def test_empty(self):

--- a/tests/features/test_rename.py
+++ b/tests/features/test_rename.py
@@ -1,11 +1,9 @@
 """Tests for rename features: prepareRename, rename for QE variables and symbols."""
 
-import pytest
 from lsprotocol import types
 
 from qe_lsp.features.rename import RenameProvider, _namelist_for_line, _word_at
 from qe_lsp.handlers.rename import prepare_rename, rename
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -132,6 +130,16 @@ class Params:
 
 
 _provider = RenameProvider()
+
+
+def _edits(result: types.WorkspaceEdit, uri: str = URI) -> list[types.TextEdit]:
+    assert result.changes is not None
+    return list(result.changes[uri])
+
+
+def _changes(result: types.WorkspaceEdit):
+    assert result.changes is not None
+    return result.changes
 
 
 # ===========================================================================
@@ -263,7 +271,7 @@ class TestRenameNamelistParameter:
         result = _provider.rename(SAMPLE_INPUT, URI, 9, 2, "kinetic_cutoff")
         assert result is not None
         assert isinstance(result, types.WorkspaceEdit)
-        edits = result.changes[URI]
+        edits = _edits(result)
         assert len(edits) == 1
         assert edits[0].new_text == "kinetic_cutoff"
         assert edits[0].range.start.line == 9
@@ -272,7 +280,7 @@ class TestRenameNamelistParameter:
         """Rename calculation -> calc_type in &CONTROL."""
         result = _provider.rename(SAMPLE_INPUT, URI, 1, 2, "calc_type")
         assert result is not None
-        edits = result.changes[URI]
+        edits = _edits(result)
         assert len(edits) == 1
         assert edits[0].new_text == "calc_type"
         assert edits[0].range.start.line == 1
@@ -281,7 +289,7 @@ class TestRenameNamelistParameter:
         """Rename celldm(1) -> lattice_a produces one edit."""
         result = _provider.rename(SAMPLE_INPUT, URI, 6, 2, "lattice_a")
         assert result is not None
-        edits = result.changes[URI]
+        edits = _edits(result)
         assert len(edits) == 1
         assert edits[0].new_text == "lattice_a"
         assert edits[0].range.start.line == 6
@@ -290,7 +298,7 @@ class TestRenameNamelistParameter:
         """Rename of a duplicated parameter edits both occurrences."""
         result = _provider.rename(DUPLICATE_PARAM_INPUT, URI, 1, 2, "calc_type")
         assert result is not None
-        edits = result.changes[URI]
+        edits = _edits(result)
         assert len(edits) == 2
         edit_lines = {e.range.start.line for e in edits}
         assert edit_lines == {1, 2}
@@ -300,7 +308,7 @@ class TestRenameNamelistParameter:
         """Triggering rename on the duplicate line itself still works."""
         result = _provider.rename(DUPLICATE_PARAM_INPUT, URI, 2, 2, "calc_type")
         assert result is not None
-        edits = result.changes[URI]
+        edits = _edits(result)
         assert len(edits) == 2
 
     def test_rename_preserves_uri(self) -> None:
@@ -308,7 +316,7 @@ class TestRenameNamelistParameter:
         custom_uri = "file:///custom/path.in"
         result = _provider.rename(SAMPLE_INPUT, custom_uri, 9, 2, "new_name")
         assert result is not None
-        assert custom_uri in result.changes
+        assert custom_uri in _changes(result)
 
 
 # ===========================================================================
@@ -324,7 +332,7 @@ class TestRenameElementSymbol:
         """Renaming Si -> Ge edits all Si rows in both cards."""
         result = _provider.rename(SAMPLE_INPUT, URI, 17, 0, "Ge")
         assert result is not None
-        edits = result.changes[URI]
+        edits = _edits(result)
         # Si appears once in ATOMIC_SPECIES (line 17) and twice in
         # ATOMIC_POSITIONS (lines 19, 20).
         assert len(edits) == 3
@@ -336,14 +344,14 @@ class TestRenameElementSymbol:
         """Triggering rename from ATOMIC_POSITIONS still edits species too."""
         result = _provider.rename(SAMPLE_INPUT, URI, 19, 0, "Ge")
         assert result is not None
-        edits = result.changes[URI]
+        edits = _edits(result)
         assert len(edits) == 3
 
     def test_rename_multi_element_selective(self) -> None:
         """Renaming only Si leaves O untouched in MULTI_ELEMENT_INPUT."""
         result = _provider.rename(MULTI_ELEMENT_INPUT, URI, 10, 0, "Ge")
         assert result is not None
-        edits = result.changes[URI]
+        edits = _edits(result)
         # Si at lines 10 (species), 13, 14 (positions) -> 3 edits
         assert len(edits) == 3
         edit_lines = {e.range.start.line for e in edits}
@@ -355,7 +363,7 @@ class TestRenameElementSymbol:
         """Renaming O -> N in MULTI_ELEMENT_INPUT edits 3 rows."""
         result = _provider.rename(MULTI_ELEMENT_INPUT, URI, 11, 0, "N")
         assert result is not None
-        edits = result.changes[URI]
+        edits = _edits(result)
         # O at lines 11 (species), 15, 16 (positions)
         assert len(edits) == 3
         edit_lines = {e.range.start.line for e in edits}
@@ -443,8 +451,8 @@ class TestRenameHandler:
         result = rename(params)
         assert result is not None
         assert isinstance(result, types.WorkspaceEdit)
-        assert URI in result.changes
-        assert result.changes[URI][0].new_text == "kinetic_cutoff"
+        assert URI in _changes(result)
+        assert _edits(result)[0].new_text == "kinetic_cutoff"
 
     def test_handler_prepare_rename_rejects(self) -> None:
         """prepare_rename handler returns None for a namelist header."""
@@ -511,7 +519,7 @@ class TestRenameEdgeCases:
         """Rename should only edit the parameter name, not its value."""
         result = _provider.rename(SAMPLE_INPUT, URI, 1, 2, "calc_type")
         assert result is not None
-        edits = result.changes[URI]
+        edits = _edits(result)
         # Only one edit for the name itself (line 1, starting at char 2).
         assert len(edits) == 1
         edit = edits[0]
@@ -521,17 +529,10 @@ class TestRenameEdgeCases:
     def test_different_namelist_same_param_name_not_renamed(self) -> None:
         """A parameter in one namelist should NOT rename a parameter with
         the same name in a different namelist."""
-        text = (
-            "&CONTROL\n"
-            "  title = 'ctrl'\n"
-            "/\n"
-            "&SYSTEM\n"
-            "  ecutwfc = 60\n"
-            "/\n"
-        )
+        text = "&CONTROL\n" "  title = 'ctrl'\n" "/\n" "&SYSTEM\n" "  ecutwfc = 60\n" "/\n"
         # Rename ecutwfc in &SYSTEM — should only edit line 4.
         result = _provider.rename(text, URI, 4, 2, "cutoff")
         assert result is not None
-        edits = result.changes[URI]
+        edits = _edits(result)
         assert len(edits) == 1
         assert edits[0].range.start.line == 4

--- a/tests/features/test_test_runner.py
+++ b/tests/features/test_test_runner.py
@@ -1,10 +1,12 @@
 """Tests for the QE test-runner / dry-run bridge."""
 
 import json
-import pytest
 from lsprotocol.types import DiagnosticSeverity
 from qe_lsp.features.test_runner import (
-    TestRunnerConfig, TestRunnerProvider, parse_solver_output, solver_output_to_diagnostics,
+    TestRunnerConfig,
+    TestRunnerProvider,
+    parse_solver_output,
+    solver_output_to_diagnostics,
     SolverOutput,
 )
 
@@ -43,14 +45,16 @@ class TestParseSolverOutput:
 
 class TestDiagnostics:
     def test_error_diagnostic(self):
-        diags = solver_output_to_diagnostics(SolverOutput(
-            errors=[{"message": "err", "line": 1, "source": "t"}]))
+        diags = solver_output_to_diagnostics(
+            SolverOutput(errors=[{"message": "err", "line": 1, "source": "t"}])
+        )
         assert diags[0].severity == DiagnosticSeverity.Error
         assert diags[0].code == "QE9001"
 
     def test_warning_diagnostic(self):
-        diags = solver_output_to_diagnostics(SolverOutput(
-            warnings=[{"message": "warn", "line": 0, "source": "t"}]))
+        diags = solver_output_to_diagnostics(
+            SolverOutput(warnings=[{"message": "warn", "line": 0, "source": "t"}])
+        )
         assert diags[0].severity == DiagnosticSeverity.Warning
         assert diags[0].code == "QE9002"
 
@@ -61,11 +65,15 @@ class TestProvider:
         assert diags[0].severity == DiagnosticSeverity.Information
 
     def test_no_exec(self):
-        diags = TestRunnerProvider(TestRunnerConfig(executable="", enabled=True)).run_validation("t")
+        diags = TestRunnerProvider(TestRunnerConfig(executable="", enabled=True)).run_validation(
+            "t"
+        )
         assert diags[0].severity == DiagnosticSeverity.Warning
 
     def test_missing_exec(self):
-        diags = TestRunnerProvider(TestRunnerConfig(executable="/no/such/bin", enabled=True)).run_validation("t")
+        diags = TestRunnerProvider(
+            TestRunnerConfig(executable="/no/such/bin", enabled=True)
+        ).run_validation("t")
         assert diags[0].severity == DiagnosticSeverity.Error
 
     def test_captured(self):
@@ -76,6 +84,8 @@ class TestProvider:
         assert len(TestRunnerProvider().run_with_captured_output("ok\n")) == 0
 
     def test_snapshot(self):
-        s = json.loads(TestRunnerProvider(TestRunnerConfig(executable="pw.x", enabled=True)).snapshot_config())
+        s = json.loads(
+            TestRunnerProvider(TestRunnerConfig(executable="pw.x", enabled=True)).snapshot_config()
+        )
         assert s["enabled"]
         assert s["executable"] == "pw.x"

--- a/tests/features/test_typecheck.py
+++ b/tests/features/test_typecheck.py
@@ -323,10 +323,7 @@ class TestRequiredSections:
         assert section_errors == []
 
     def test_vc_relax_without_cell_namelist(self, provider: TypecheckProvider) -> None:
-        text = (
-            "&CONTROL\ncalculation = 'vc-relax'\n/\n"
-            "&SYSTEM\nibrav = 1\necutwfc = 60\n/\n"
-        )
+        text = "&CONTROL\ncalculation = 'vc-relax'\n/\n" "&SYSTEM\nibrav = 1\necutwfc = 60\n/\n"
         diagnostics = provider.typecheck(text)
         section_errors = [d for d in diagnostics if d.code == RULE_REQUIRED_SECTION_MISSING]
         assert any("&CELL" in d.message for d in section_errors)
@@ -481,10 +478,7 @@ class TestSnapshot:
         assert items[0]["code"].startswith("QE-")
 
     def test_snapshot_deterministic_ordering(self, provider: TypecheckProvider) -> None:
-        text = (
-            "&SYSTEM\nibrav = abc\n/\n"
-            "&CONTROL\ncalculation = 'bogus'\n/\n"
-        )
+        text = "&SYSTEM\nibrav = abc\n/\n" "&CONTROL\ncalculation = 'bogus'\n/\n"
         first = provider.snapshot(text)
         second = provider.snapshot(text)
         assert first == second


### PR DESCRIPTION
## Summary
- Run repo-standard formatting across src and tests.
- Fix Ruff/mypy/pre-commit drift in existing QE code and tests.
- Keep this cleanup separate from real-world fixture PR #53.

## Verification
- uv run black --check src tests
- uv run ruff check .
- uv run mypy src tests
- uv run pre-commit run --all-files
- uv run python -m pytest -q