### PR TITLE
feat: implement RULE qe.input.missing_control (QE-E008)

### DIFF
--- a/src/qe_lsp/features/code_actions.py
+++ b/src/qe_lsp/features/code_actions.py
@@ -29,6 +29,7 @@ from ..features.lint import (
     RULE_INVALID_KEYWORD_VALUE,
     RULE_MISSING_ATOMIC_POSITIONS,
     RULE_MISSING_ATOMIC_SPECIES,
+    RULE_MISSING_CONTROL,
     RULE_MISSING_CONTROL_CALC,
     RULE_MISSING_REQUIRED_SECTION,
     RULE_MISSING_SYSTEM_ECUTWFC,
@@ -202,6 +203,7 @@ class CodeActionProvider:
         # Missing required sections -> add skeleton
         if code in (
             RULE_MISSING_REQUIRED_SECTION,
+            RULE_MISSING_CONTROL,
             RULE_MISSING_CONTROL_CALC,
             RULE_MISSING_SYSTEM_ECUTWFC,
             RULE_MISSING_ATOMIC_SPECIES,
@@ -584,6 +586,13 @@ class CodeActionProvider:
                     "Add &SYSTEM namelist skeleton",
                 )
             return None
+
+        if code == RULE_MISSING_CONTROL:
+            return self._add_skeleton(
+                diagnostic,
+                "&CONTROL\n  calculation = 'scf'\n/\n\n",
+                "Add &CONTROL namelist skeleton",
+            )
 
         if code == RULE_MISSING_CONTROL_CALC:
             return self._add_after_namelist(

--- a/src/qe_lsp/features/lint.py
+++ b/src/qe_lsp/features/lint.py
@@ -34,6 +34,7 @@ RULE_MISSING_SYSTEM_ECUTWFC = "QE-E005"
 RULE_MISSING_ATOMIC_SPECIES = "QE-E006"
 RULE_MISSING_ATOMIC_POSITIONS = "QE-E007"
 RULE_ORPHAN_PARAMETER = "QE-W004"
+RULE_MISSING_CONTROL = "QE-E008"
 
 # ------------------------------------------------------------------
 # Schema data
@@ -351,6 +352,7 @@ class LintProvider:
         parsed = parse_qe_input(text)
         diagnostics: list[Diagnostic] = []
 
+        self._check_missing_control(parsed, diagnostics)
         self._check_required_sections(parsed, text, diagnostics)
         self._check_unknown_namelists(parsed, diagnostics)
         self._check_unknown_keywords(parsed, diagnostics)
@@ -376,6 +378,26 @@ class LintProvider:
     # Individual checks
     # ------------------------------------------------------------------
 
+    def _check_missing_control(
+        self,
+        parsed: Any,
+        diagnostics: list[Diagnostic],
+    ) -> None:
+        """Emit QE-E008 when &CONTROL namelist is absent."""
+        if not parsed.namelists:
+            return
+        if "&CONTROL" not in parsed.namelists:
+            diagnostics.append(
+                self._make(
+                    line=0,
+                    char=0,
+                    length=0,
+                    message="Missing required namelist &CONTROL.",
+                    severity=DiagnosticSeverity.Error,
+                    code=RULE_MISSING_CONTROL,
+                )
+            )
+
     def _check_required_sections(
         self,
         parsed: Any,
@@ -389,18 +411,7 @@ class LintProvider:
             return
 
         control = namelists.get("&CONTROL", {})
-        if not control:
-            diagnostics.append(
-                self._make(
-                    line=0,
-                    char=0,
-                    length=0,
-                    message="Missing required namelist &CONTROL.",
-                    severity=DiagnosticSeverity.Error,
-                    code=RULE_MISSING_REQUIRED_SECTION,
-                )
-            )
-        elif "calculation" not in control:
+        if control and "calculation" not in control:
             diagnostics.append(
                 self._make(
                     line=0,
@@ -520,9 +531,7 @@ class LintProvider:
                 if raw_value not in valid_values:
                     raw_display = _strip_quotes(param.value)
                     valid_str = ", ".join(sorted(valid_values))
-                    msg = (
-                        f"Invalid value '{raw_display}' for '{param_name}'. " f"Valid: {valid_str}."
-                    )
+                    msg = f"Invalid value '{raw_display}' for '{param_name}'. Valid: {valid_str}."
                     diagnostics.append(
                         self._make(
                             line=param.line,
@@ -632,7 +641,7 @@ class LintProvider:
                         char=0,
                         length=0,
                         message=(
-                            f"calculation='{calc}' usually requires explicit " "nbnd in &SYSTEM."
+                            f"calculation='{calc}' usually requires explicit nbnd in &SYSTEM."
                         ),
                         severity=DiagnosticSeverity.Warning,
                         code=RULE_INCONSISTENT_SETTINGS,

--- a/src/qe_lsp/features/typecheck.py
+++ b/src/qe_lsp/features/typecheck.py
@@ -591,8 +591,7 @@ class TypecheckProvider:
                     diagnostics.append(
                         _make_diagnostic(
                             param,
-                            f"Value {numeric_value} for '{_param_name}' exceeds "
-                            f"maximum {max_val}.",
+                            f"Value {numeric_value} for '{_param_name}' exceeds maximum {max_val}.",
                             DiagnosticSeverity.Warning,
                             RULE_NUMERIC_RANGE,
                         )

--- a/tests/features/test_code_actions.py
+++ b/tests/features/test_code_actions.py
@@ -21,6 +21,7 @@ from qe_lsp.features.lint import (
     RULE_INVALID_KEYWORD_VALUE,
     RULE_MISSING_ATOMIC_POSITIONS,
     RULE_MISSING_ATOMIC_SPECIES,
+    RULE_MISSING_CONTROL,
     RULE_MISSING_CONTROL_CALC,
     RULE_MISSING_REQUIRED_SECTION,
     RULE_MISSING_SYSTEM_ECUTWFC,
@@ -216,7 +217,7 @@ class TestFixMixingBeta:
 
 class TestFixEcutrhoRatio:
     def test_adjusts_ecutrho_to_ratio(self, provider: CodeActionProvider) -> None:
-        source = "&SYSTEM\n" "ibrav = 1\n" "ecutwfc = 60.0\n" "ecutrho = 100.0\n" "/\n"
+        source = "&SYSTEM\nibrav = 1\necutwfc = 60.0\necutrho = 100.0\n/\n"
         diags = validate_qe_input(source)
         ratio_warnings = [d for d in diags if "ecutrho should normally" in d.message]
         assert len(ratio_warnings) >= 1
@@ -261,10 +262,9 @@ class TestFixMissingSections:
     def test_adds_control_skeleton(self, provider: CodeActionProvider) -> None:
         source = "&SYSTEM\nibrav = 1\n/\n"
         diags = LintProvider().lint(source)
-        missing = [d for d in diags if d.code == RULE_MISSING_REQUIRED_SECTION]
-        assert any("&CONTROL" in d.message for d in missing)
+        control_diags = [d for d in diags if d.code == RULE_MISSING_CONTROL]
+        assert len(control_diags) >= 1
 
-        control_diags = [d for d in missing if "&CONTROL" in d.message]
         actions = provider.get_code_actions(source, control_diags)
         assert len(actions) >= 1
         assert any("&CONTROL" in a.title for a in actions)

--- a/tests/features/test_diagnostic.py
+++ b/tests/features/test_diagnostic.py
@@ -117,7 +117,7 @@ class TestSnapshot:
 
     def test_snapshot_deterministic_ordering(self, provider: DiagnosticProvider) -> None:
         """Two calls with the same text must produce the same output."""
-        text = "&SYSTEM\n" "ibrav = 0\n" "/\n" "&CONTROL\n" "calculation = 'scf'\n"
+        text = "&SYSTEM\nibrav = 0\n/\n&CONTROL\ncalculation = 'scf'\n"
         first = provider.snapshot(text)
         second = provider.snapshot(text)
         assert first == second

--- a/tests/features/test_formatting.py
+++ b/tests/features/test_formatting.py
@@ -263,7 +263,7 @@ class TestFormatRange:
         assert provider.format_range("", params) == []
 
     def test_range_within_namelist(self, provider: FormattingProvider) -> None:
-        text = "&CONTROL\n" "calculation = 'scf'\n" "/\n"
+        text = "&CONTROL\ncalculation = 'scf'\n/\n"
         # Format only line 1 (the assignment)
         params = _range_params(1, 1)
         edits = provider.format_range(text, params)
@@ -271,14 +271,14 @@ class TestFormatRange:
         assert "  calculation = 'scf'" in edits[0].new_text
 
     def test_range_includes_namelist_header(self, provider: FormattingProvider) -> None:
-        text = "&CONTROL\n" "calculation = 'scf'\n" "/\n"
+        text = "&CONTROL\ncalculation = 'scf'\n/\n"
         # Format lines 0-2
         params = _range_params(0, 2)
         edits = provider.format_range(text, params)
         assert len(edits) == 1
 
     def test_already_formatted_range(self, provider: FormattingProvider) -> None:
-        text = "&CONTROL\n" "  calculation = 'scf'\n" "/\n"
+        text = "&CONTROL\n  calculation = 'scf'\n/\n"
         params = _range_params(1, 1)
         edits = provider.format_range(text, params)
         assert edits == []
@@ -292,7 +292,7 @@ class TestFormatRange:
 
     def test_range_preserves_surrounding_context(self, provider: FormattingProvider) -> None:
         """Range formatting must not affect lines outside the range."""
-        text = "&CONTROL\n" "calculation = 'scf'\n" "/\n" "&SYSTEM\n" "ibrav = 1\n" "/\n"
+        text = "&CONTROL\ncalculation = 'scf'\n/\n&SYSTEM\nibrav = 1\n/\n"
         # Format only line 4 (ibrav = 1)
         params = _range_params(4, 4)
         edits = provider.format_range(text, params)
@@ -300,12 +300,7 @@ class TestFormatRange:
         assert "  ibrav = 1" in edits[0].new_text
 
     def test_range_with_card(self, provider: FormattingProvider) -> None:
-        text = (
-            "ATOMIC_SPECIES\n"
-            "Si 28.086 Si.pbe.UPF\n"
-            "ATOMIC_POSITIONS {crystal}\n"
-            "Si 0.0 0.0 0.0\n"
-        )
+        text = "ATOMIC_SPECIES\nSi 28.086 Si.pbe.UPF\nATOMIC_POSITIONS {crystal}\nSi 0.0 0.0 0.0\n"
         # Format lines 1 and 3 (card data rows)
         params = _range_params(1, 1)
         edits = provider.format_range(text, params)

--- a/tests/features/test_lint.py
+++ b/tests/features/test_lint.py
@@ -11,6 +11,7 @@ from qe_lsp.features.lint import (
     RULE_INVALID_KEYWORD_VALUE,
     RULE_MISSING_ATOMIC_POSITIONS,
     RULE_MISSING_ATOMIC_SPECIES,
+    RULE_MISSING_CONTROL,
     RULE_MISSING_CONTROL_CALC,
     RULE_MISSING_REQUIRED_SECTION,
     RULE_MISSING_SYSTEM_ECUTWFC,
@@ -177,6 +178,30 @@ class TestLintErrors:
         codes = [d.code for d in diagnostics]
         assert RULE_MISSING_CONTROL_CALC in codes
 
+    def test_rule_missing_control_namelist(self, provider: LintProvider) -> None:
+        """RULE qe.input.missing_control: error when &CONTROL namelist is absent."""
+        text = "&SYSTEM\n  ibrav = 2,\n/\n"
+        diagnostics = provider.lint(text)
+        missing = [d for d in diagnostics if d.code == RULE_MISSING_CONTROL]
+        assert len(missing) == 1
+        assert "CONTROL" in missing[0].message
+        assert missing[0].severity is not None
+        assert missing[0].severity.value == 1  # Error
+
+    def test_missing_control_with_only_electrons(self, provider: LintProvider) -> None:
+        """Even &ELECTRONS alone should trigger missing &CONTROL."""
+        text = "&ELECTRONS\nconv_thr = 1e-8\n/\n"
+        diagnostics = provider.lint(text)
+        missing = [d for d in diagnostics if d.code == RULE_MISSING_CONTROL]
+        assert len(missing) == 1
+
+    def test_control_present_no_missing_control_error(self, provider: LintProvider) -> None:
+        """When &CONTROL exists, RULE_MISSING_CONTROL should NOT fire."""
+        text = "&CONTROL\ncalculation = 'scf'\n/\n"
+        diagnostics = provider.lint(text)
+        missing = [d for d in diagnostics if d.code == RULE_MISSING_CONTROL]
+        assert missing == []
+
     def test_missing_system_ecutwfc(self, provider: LintProvider) -> None:
         text = "&CONTROL\ncalculation = 'scf'\n/\n&SYSTEM\nibrav = 1\n/\n"
         diagnostics = provider.lint(text)
@@ -184,15 +209,7 @@ class TestLintErrors:
         assert RULE_MISSING_SYSTEM_ECUTWFC in codes
 
     def test_vc_relax_without_cell_namelist(self, provider: LintProvider) -> None:
-        text = (
-            "&CONTROL\n"
-            "  calculation = 'vc-relax'\n"
-            "/\n"
-            "&SYSTEM\n"
-            "  ibrav = 1\n"
-            "  ecutwfc = 60\n"
-            "/\n"
-        )
+        text = "&CONTROL\n  calculation = 'vc-relax'\n/\n&SYSTEM\n  ibrav = 1\n  ecutwfc = 60\n/\n"
         diagnostics = provider.lint(text)
         errors = [d for d in diagnostics if d.code == RULE_INCONSISTENT_SETTINGS]
         assert any("&CELL" in d.message for d in errors)
@@ -232,7 +249,7 @@ class TestLintSourceAndCode:
         assert diagnostics[0].code.startswith("QE-")
 
     def test_valid_enum_values_no_error(self, provider: LintProvider) -> None:
-        text = "&CONTROL\ncalculation = 'scf'\n/\n" "&ELECTRONS\nmixing_mode = 'plain'\n/\n"
+        text = "&CONTROL\ncalculation = 'scf'\n/\n&ELECTRONS\nmixing_mode = 'plain'\n/\n"
         diagnostics = provider.lint(text)
         invalids = [d for d in diagnostics if d.code == RULE_INVALID_KEYWORD_VALUE]
         assert invalids == []
@@ -306,7 +323,7 @@ class TestSnapshot:
         assert error_items[0]["code"].startswith("QE-")
 
     def test_snapshot_deterministic_ordering(self, provider: LintProvider) -> None:
-        text = "&FOOBAR\nx = 1\n/\n" "&CONTROL\ncalculation = 'bogus'\n/\n"
+        text = "&FOOBAR\nx = 1\n/\n&CONTROL\ncalculation = 'bogus'\n/\n"
         first = provider.snapshot(text)
         second = provider.snapshot(text)
         assert first == second

--- a/tests/features/test_rename.py
+++ b/tests/features/test_rename.py
@@ -530,7 +530,7 @@ class TestRenameEdgeCases:
     def test_different_namelist_same_param_name_not_renamed(self) -> None:
         """A parameter in one namelist should NOT rename a parameter with
         the same name in a different namelist."""
-        text = "&CONTROL\n" "  title = 'ctrl'\n" "/\n" "&SYSTEM\n" "  ecutwfc = 60\n" "/\n"
+        text = "&CONTROL\n  title = 'ctrl'\n/\n&SYSTEM\n  ecutwfc = 60\n/\n"
         # Rename ecutwfc in &SYSTEM — should only edit line 4.
         result = _provider.rename(text, URI, 4, 2, "cutoff")
         assert result is not None

--- a/tests/features/test_typecheck.py
+++ b/tests/features/test_typecheck.py
@@ -323,7 +323,7 @@ class TestRequiredSections:
         assert section_errors == []
 
     def test_vc_relax_without_cell_namelist(self, provider: TypecheckProvider) -> None:
-        text = "&CONTROL\ncalculation = 'vc-relax'\n/\n" "&SYSTEM\nibrav = 1\necutwfc = 60\n/\n"
+        text = "&CONTROL\ncalculation = 'vc-relax'\n/\n&SYSTEM\nibrav = 1\necutwfc = 60\n/\n"
         diagnostics = provider.typecheck(text)
         section_errors = [d for d in diagnostics if d.code == RULE_REQUIRED_SECTION_MISSING]
         assert any("&CELL" in d.message for d in section_errors)
@@ -478,7 +478,7 @@ class TestSnapshot:
         assert items[0]["code"].startswith("QE-")
 
     def test_snapshot_deterministic_ordering(self, provider: TypecheckProvider) -> None:
-        text = "&SYSTEM\nibrav = abc\n/\n" "&CONTROL\ncalculation = 'bogus'\n/\n"
+        text = "&SYSTEM\nibrav = abc\n/\n&CONTROL\ncalculation = 'bogus'\n/\n"
         first = provider.snapshot(text)
         second = provider.snapshot(text)
         assert first == second

--- a/tests/fixtures/rules/missing_control.json
+++ b/tests/fixtures/rules/missing_control.json
@@ -1,0 +1,6 @@
+{
+  "rule_id": "qe.input.missing_control",
+  "diagnostic_code": "QE-E008",
+  "severity": "error",
+  "message_pattern": "CONTROL"
+}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -108,9 +108,7 @@ def test_diagnostic_reports_pseudopotential_element_mismatch():
 def test_diagnostic_reports_atomic_positions_without_species():
     """All positioned atoms need a matching ATOMIC_SPECIES entry."""
     diagnostics = diagnostic(
-        Params(
-            "ATOMIC_SPECIES\nO 15.999 O.pbe.UPF\n" "ATOMIC_POSITIONS {crystal}\nSi 0.0 0.0 0.0\n"
-        )
+        Params("ATOMIC_SPECIES\nO 15.999 O.pbe.UPF\nATOMIC_POSITIONS {crystal}\nSi 0.0 0.0 0.0\n")
     )
 
     assert len(diagnostics) == 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -351,9 +351,7 @@ class TestAgentAPIWithFixtures:
 
 class TestTestRunnerProviderIntegration:
     def test_parse_output_from_real_error(self) -> None:
-        output = (
-            "     from line  10 : calculation type not implemented\n" "% error in calculation\n"
-        )
+        output = "     from line  10 : calculation type not implemented\n% error in calculation\n"
         result = parse_solver_output(output)
         assert not result.success
 
@@ -397,5 +395,5 @@ class TestCrossProviderAgreement:
         all_diags = validation_diags + lint_diags + typecheck_diags
         errors = [d for d in all_diags if d.severity is not None and d.severity.value == 1]
         assert errors == [], (
-            f"Unexpected errors in {fixture_name}: " f"{[(d.source, d.message) for d in errors]}"
+            f"Unexpected errors in {fixture_name}: {[(d.source, d.message) for d in errors]}"
         )

--- a/tests/test_qe_examples.py
+++ b/tests/test_qe_examples.py
@@ -161,9 +161,9 @@ class TestDiagnosticStability:
         lint = LintProvider()
         diagnostics = lint.lint(text)
         errors = [d for d in diagnostics if d.severity is not None and d.severity.value == 1]
-        assert (
-            errors == []
-        ), f"Unexpected lint errors in {fixture_name}: {[d.message for d in errors]}"
+        assert errors == [], (
+            f"Unexpected lint errors in {fixture_name}: {[d.message for d in errors]}"
+        )
 
     @pytest.mark.parametrize("fixture_name", VALID_FIXTURES, ids=VALID_FIXTURES)
     def test_typecheck_no_errors(self, fixture_name: str) -> None:
@@ -171,9 +171,9 @@ class TestDiagnosticStability:
         tc = TypecheckProvider()
         diagnostics = tc.typecheck(text)
         errors = [d for d in diagnostics if d.severity is not None and d.severity.value == 1]
-        assert (
-            errors == []
-        ), f"Unexpected typecheck errors in {fixture_name}: {[d.message for d in errors]}"
+        assert errors == [], (
+            f"Unexpected typecheck errors in {fixture_name}: {[d.message for d in errors]}"
+        )
 
     def test_diagnostic_snapshot_deterministic(self) -> None:
         """Two diagnostic runs must produce identical results."""
@@ -433,7 +433,7 @@ class TestCommonInvalidCases:
 
     def test_missing_ecutwfc_without_nat(self) -> None:
         """When both ecutwfc and nat are missing from &SYSTEM, report ecutwfc."""
-        text = "&CONTROL\ncalculation = 'scf'\n/\n" "&SYSTEM\nibrav = 1\n/\n"
+        text = "&CONTROL\ncalculation = 'scf'\n/\n&SYSTEM\nibrav = 1\n/\n"
         diags = LintProvider().lint(text)
         assert any("ecutwfc" in d.message for d in diags)
 
@@ -468,16 +468,12 @@ class TestCommonInvalidCases:
     # --- Atomic positions errors ---
 
     def test_atom_not_in_species(self) -> None:
-        text = (
-            "ATOMIC_SPECIES\nSi 28.086 Si.pbe.UPF\n" "ATOMIC_POSITIONS {crystal}\nO 0.0 0.0 0.0\n"
-        )
+        text = "ATOMIC_SPECIES\nSi 28.086 Si.pbe.UPF\nATOMIC_POSITIONS {crystal}\nO 0.0 0.0 0.0\n"
         diags = validate_qe_input(text)
         assert any("missing from ATOMIC_SPECIES" in d.message for d in diags)
 
     def test_crystal_coords_out_of_bounds(self) -> None:
-        text = (
-            "ATOMIC_SPECIES\nSi 28.086 Si.pbe.UPF\n" "ATOMIC_POSITIONS {crystal}\nSi 1.5 0.0 0.0\n"
-        )
+        text = "ATOMIC_SPECIES\nSi 28.086 Si.pbe.UPF\nATOMIC_POSITIONS {crystal}\nSi 1.5 0.0 0.0\n"
         diags = validate_qe_input(text)
         assert any("between 0 and 1" in d.message for d in diags)
 
@@ -501,7 +497,7 @@ class TestCommonInvalidCases:
         assert any("at least 4x ecutwfc" in d.message for d in diags)
 
     def test_ecutrho_too_low_paw(self) -> None:
-        text = "&SYSTEM\necutwfc = 60\necutrho = 300\n/\n" "ATOMIC_SPECIES\nO 15.999 O.paw.UPF\n"
+        text = "&SYSTEM\necutwfc = 60\necutrho = 300\n/\nATOMIC_SPECIES\nO 15.999 O.paw.UPF\n"
         diags = validate_qe_input(text)
         assert any("at least 8x ecutwfc" in d.message for d in diags)
 
@@ -539,9 +535,7 @@ class TestCommonInvalidCases:
     # --- nspin without magnetization ---
 
     def test_nspin_without_magnetization(self) -> None:
-        text = (
-            "&CONTROL\ncalculation = 'scf'\n/\n" "&SYSTEM\nibrav = 1\nnspin = 2\necutwfc = 60\n/\n"
-        )
+        text = "&CONTROL\ncalculation = 'scf'\n/\n&SYSTEM\nibrav = 1\nnspin = 2\necutwfc = 60\n/\n"
         diags = LintProvider().lint(text)
         assert any("nspin > 1" in d.message for d in diags)
 

--- a/tests/test_validation_accuracy.py
+++ b/tests/test_validation_accuracy.py
@@ -35,7 +35,7 @@ VALIDATION_CASES = [
     ),
     ValidationCase(
         "paw_cutoff_ratio",
-        "&SYSTEM\necutwfc = 60\necutrho = 300\n/\n" "ATOMIC_SPECIES\nO 15.999 O.paw.UPF\n",
+        "&SYSTEM\necutwfc = 60\necutrho = 300\n/\nATOMIC_SPECIES\nO 15.999 O.paw.UPF\n",
         ["at least 8x ecutwfc"],
     ),
     ValidationCase(
@@ -55,12 +55,12 @@ VALIDATION_CASES = [
     ),
     ValidationCase(
         "position_species_mismatch",
-        "ATOMIC_SPECIES\nO 15.999 O.pbe.UPF\n" "ATOMIC_POSITIONS {crystal}\nSi 0.0 0.0 0.0\n",
+        "ATOMIC_SPECIES\nO 15.999 O.pbe.UPF\nATOMIC_POSITIONS {crystal}\nSi 0.0 0.0 0.0\n",
         ["missing from ATOMIC_SPECIES"],
     ),
     ValidationCase(
         "crystal_position_bounds",
-        "ATOMIC_SPECIES\nO 15.999 O.pbe.UPF\n" "ATOMIC_POSITIONS {crystal}\nO 1.2 0.0 0.0\n",
+        "ATOMIC_SPECIES\nO 15.999 O.pbe.UPF\nATOMIC_POSITIONS {crystal}\nO 1.2 0.0 0.0\n",
         ["between 0 and 1"],
     ),
     ValidationCase(
@@ -75,7 +75,7 @@ VALIDATION_CASES = [
     ),
     ValidationCase(
         "valid_species_and_positions",
-        "ATOMIC_SPECIES\nO 15.999 O.pbe.UPF\n" "ATOMIC_POSITIONS {crystal}\nO 0.0 0.5 1.0\n",
+        "ATOMIC_SPECIES\nO 15.999 O.pbe.UPF\nATOMIC_POSITIONS {crystal}\nO 0.0 0.5 1.0\n",
         [],
         "missing from ATOMIC_SPECIES",
     ),


### PR DESCRIPTION
Adds diagnostic for missing &CONTROL namelist in QE input files.

Changes:
- Add RULE_MISSING_CONTROL (QE-E008) constant to lint.py
- Add _check_missing_control method that fires when any namelist exists but &CONTROL is absent
- Update _check_required_sections to avoid double-reporting missing &CONTROL
- Wire RULE_MISSING_CONTROL into CodeActionProvider for quick-fix skeleton insertion
- Add 3 new tests covering the rule (missing with SYSTEM, missing with ELECTRONS, not fired when CONTROL present)
- Add golden fixture tests/fixtures/rules/missing_control.json

All 446 tests pass with 100% coverage.

Fixes #61