### PR TITLE
feat: implement RULE qe.input.bad_calculation

### DIFF
--- a/src/qe_lsp/features/code_actions.py
+++ b/src/qe_lsp/features/code_actions.py
@@ -24,6 +24,7 @@ from ..parser import parse_qe_input
 from ..features.lint import (
     KNOWN_PARAMETERS,
     VALID_NAMELISTS,
+    RULE_BAD_CALCULATION,
     RULE_DEPRECATED_KEYWORD,
     RULE_INCONSISTENT_SETTINGS,
     RULE_INVALID_KEYWORD_VALUE,
@@ -177,7 +178,7 @@ class CodeActionProvider:
             return self._fix_unknown_keyword(source, diagnostic)
 
         # Invalid enum value -> suggest closest valid value
-        if code == RULE_INVALID_KEYWORD_VALUE:
+        if code in (RULE_INVALID_KEYWORD_VALUE, RULE_BAD_CALCULATION):
             return self._fix_invalid_value(source, diagnostic)
 
         # Deprecated keyword -> replace with modern alternative

--- a/src/qe_lsp/features/lint.py
+++ b/src/qe_lsp/features/lint.py
@@ -35,6 +35,7 @@ RULE_MISSING_ATOMIC_SPECIES = "QE-E006"
 RULE_MISSING_ATOMIC_POSITIONS = "QE-E007"
 RULE_ORPHAN_PARAMETER = "QE-W004"
 RULE_MISSING_CONTROL = "QE-E008"
+RULE_BAD_CALCULATION = "QE-E009"
 
 # ------------------------------------------------------------------
 # Schema data
@@ -227,6 +228,8 @@ VALID_CALCULATIONS = frozenset(
         "md",
         "vc-relax",
         "vc-md",
+        "cp",
+        "vc-cp",
     }
 )
 VALID_DIAGALIZATIONS = frozenset(
@@ -306,7 +309,7 @@ VALID_CELL_DOFREE = frozenset(
 
 #: Keyword -> (valid values, rule code for invalid value)
 VALUE_CONSTRAINTS: dict[str, tuple[frozenset[str], str]] = {
-    "calculation": (VALID_CALCULATIONS, RULE_INVALID_KEYWORD_VALUE),
+    "calculation": (VALID_CALCULATIONS, RULE_BAD_CALCULATION),
     "diagonalization": (VALID_DIAGALIZATIONS, RULE_INVALID_KEYWORD_VALUE),
     "mixing_mode": (VALID_MIXING_MODES, RULE_INVALID_KEYWORD_VALUE),
     "smearing": (VALID_SMEARING, RULE_INVALID_KEYWORD_VALUE),

--- a/tests/features/test_code_actions.py
+++ b/tests/features/test_code_actions.py
@@ -16,6 +16,7 @@ from lsprotocol.types import (
 from qe_lsp.features.code_actions import CodeActionProvider
 from qe_lsp.features.lint import (
     LintProvider,
+    RULE_BAD_CALCULATION,
     RULE_DEPRECATED_KEYWORD,
     RULE_INCONSISTENT_SETTINGS,
     RULE_INVALID_KEYWORD_VALUE,
@@ -137,7 +138,7 @@ class TestFixInvalidValue:
     def test_suggests_closest_valid_calculation(self, provider: CodeActionProvider) -> None:
         source = "&CONTROL\ncalculation = 'bogus'\n/\n"
         diags = LintProvider().lint(source)
-        invalids = [d for d in diags if d.code == RULE_INVALID_KEYWORD_VALUE]
+        invalids = [d for d in diags if d.code == RULE_BAD_CALCULATION]
         assert len(invalids) >= 1
 
         actions = provider.get_code_actions(source, invalids)

--- a/tests/features/test_lint.py
+++ b/tests/features/test_lint.py
@@ -6,6 +6,7 @@ import pytest
 
 from qe_lsp.features.lint import (
     LintProvider,
+    RULE_BAD_CALCULATION,
     RULE_DEPRECATED_KEYWORD,
     RULE_INCONSISTENT_SETTINGS,
     RULE_INVALID_KEYWORD_VALUE,
@@ -156,9 +157,27 @@ class TestLintErrors:
     def test_invalid_calculation_value(self, provider: LintProvider) -> None:
         text = "&CONTROL\ncalculation = 'bogus'\n/\n"
         diagnostics = provider.lint(text)
-        invalids = [d for d in diagnostics if d.code == RULE_INVALID_KEYWORD_VALUE]
-        assert len(invalids) == 1
-        assert "bogus" in invalids[0].message
+        bad_calc = [d for d in diagnostics if d.code == RULE_BAD_CALCULATION]
+        assert len(bad_calc) == 1
+        assert "bogus" in bad_calc[0].message
+        assert bad_calc[0].severity is not None
+        assert bad_calc[0].severity.value == 1  # Error
+
+    def test_valid_calculation_values_no_error(self, provider: LintProvider) -> None:
+        """All known valid calculation values should NOT trigger RULE_BAD_CALCULATION."""
+        for calc in ("scf", "nscf", "bands", "relax", "md", "vc-relax", "vc-md", "cp", "vc-cp"):
+            text = f"&CONTROL\ncalculation = '{calc}'\n/\n"
+            diagnostics = provider.lint(text)
+            bad_calc = [d for d in diagnostics if d.code == RULE_BAD_CALCULATION]
+            assert bad_calc == [], f"calculation='{calc}' should be valid"
+
+    def test_missing_calculation_no_bad_calculation_error(self, provider: LintProvider) -> None:
+        """Missing 'calculation' keyword is covered by RULE_MISSING_CONTROL_CALC,
+        not by RULE_BAD_CALCULATION."""
+        text = "&CONTROL\noutdir = './tmp'\n/\n"
+        diagnostics = provider.lint(text)
+        bad_calc = [d for d in diagnostics if d.code == RULE_BAD_CALCULATION]
+        assert bad_calc == []
 
     def test_invalid_diagonalization_value(self, provider: LintProvider) -> None:
         text = "&ELECTRONS\ndiagonalization = 'invalid_method'\n/\n"

--- a/tests/fixtures/rules/bad_calculation.json
+++ b/tests/fixtures/rules/bad_calculation.json
@@ -1,0 +1,6 @@
+{
+  "rule_id": "qe.input.bad_calculation",
+  "diagnostic_code": "QE-E009",
+  "severity": "error",
+  "message_pattern": "calculation"
+}


### PR DESCRIPTION
Adds diagnostic for invalid calculation value in &CONTROL namelist. Fixes #62

Changes:
- Add RULE_BAD_CALCULATION (QE-E009) dedicated diagnostic code
- Expand VALID_CALCULATIONS with cp and vc-cp
- Update VALUE_CONSTRAINTS to use dedicated rule code for calculation
- Update CodeActionProvider to handle the new rule code
- Add tests for invalid, valid (including cp/vc-cp), and missing calculation
- Add golden fixture tests/fixtures/rules/bad_calculation.json