### PR TITLE
feat: implement RULE qe.scf.conv_thr_loose

### DIFF
--- a/src/qe_lsp/features/lint.py
+++ b/src/qe_lsp/features/lint.py
@@ -36,6 +36,7 @@ RULE_MISSING_ATOMIC_POSITIONS = "QE-E007"
 RULE_ORPHAN_PARAMETER = "QE-W004"
 RULE_MISSING_CONTROL = "QE-E008"
 RULE_BAD_CALCULATION = "QE-E009"
+RULE_CONV_THR_LOOSE = "QE-W010"
 
 # ------------------------------------------------------------------
 # Schema data
@@ -362,6 +363,7 @@ class LintProvider:
         self._check_invalid_values(parsed, diagnostics)
         self._check_deprecated_keywords(parsed, diagnostics)
         self._check_inconsistent_settings(parsed, diagnostics)
+        self._check_conv_thr_loose(parsed, diagnostics)
         self._check_orphan_parameters(parsed, text, diagnostics)
 
         return diagnostics
@@ -650,6 +652,32 @@ class LintProvider:
                         code=RULE_INCONSISTENT_SETTINGS,
                     )
                 )
+
+    def _check_conv_thr_loose(
+        self,
+        parsed: Any,
+        diagnostics: list[Diagnostic],
+    ) -> None:
+        """Emit QE-W010 when conv_thr in &ELECTRONS is set above 1e-4."""
+        electrons = parsed.namelists.get("&ELECTRONS", {})
+        param = electrons.get("conv_thr")
+        if param is None:
+            return
+        value = parse_number(param.value)
+        if value is not None and value > 1e-4:
+            diagnostics.append(
+                self._make(
+                    line=param.line,
+                    char=param.character,
+                    length=len("conv_thr"),
+                    message=(
+                        f"conv_thr = {value} is too loose. "
+                        "Consider tightening to <= 1e-4 for reliable SCF convergence."
+                    ),
+                    severity=DiagnosticSeverity.Warning,
+                    code=RULE_CONV_THR_LOOSE,
+                )
+            )
 
     def _check_orphan_parameters(
         self,

--- a/tests/features/test_lint.py
+++ b/tests/features/test_lint.py
@@ -7,6 +7,7 @@ import pytest
 from qe_lsp.features.lint import (
     LintProvider,
     RULE_BAD_CALCULATION,
+    RULE_CONV_THR_LOOSE,
     RULE_DEPRECATED_KEYWORD,
     RULE_INCONSISTENT_SETTINGS,
     RULE_INVALID_KEYWORD_VALUE,
@@ -250,6 +251,53 @@ class TestLintErrors:
         diagnostics = provider.lint(text)
         codes = [d.code for d in diagnostics]
         assert RULE_MISSING_ATOMIC_POSITIONS in codes
+
+
+class TestConvThrLoose:
+    """RULE qe.scf.conv_thr_loose (QE-W010): warn when conv_thr > 1e-4."""
+
+    def test_loose_conv_thr_triggers_warning(self, provider: LintProvider) -> None:
+        text = "&ELECTRONS\n  conv_thr = 1e-3\n/\n"
+        diagnostics = provider.lint(text)
+        loose = [d for d in diagnostics if d.code == RULE_CONV_THR_LOOSE]
+        assert len(loose) == 1
+        assert "conv_thr" in loose[0].message
+        assert loose[0].severity is not None
+        assert loose[0].severity.value == 2  # Warning
+
+    def test_tight_conv_thr_no_warning(self, provider: LintProvider) -> None:
+        text = "&ELECTRONS\n  conv_thr = 1e-8\n/\n"
+        diagnostics = provider.lint(text)
+        loose = [d for d in diagnostics if d.code == RULE_CONV_THR_LOOSE]
+        assert loose == []
+
+    def test_exact_threshold_no_warning(self, provider: LintProvider) -> None:
+        """conv_thr = 1e-4 exactly should NOT trigger the warning."""
+        text = "&ELECTRONS\n  conv_thr = 1e-4\n/\n"
+        diagnostics = provider.lint(text)
+        loose = [d for d in diagnostics if d.code == RULE_CONV_THR_LOOSE]
+        assert loose == []
+
+    def test_no_conv_thr_no_warning(self, provider: LintProvider) -> None:
+        text = "&ELECTRONS\n  mixing_beta = 0.7\n/\n"
+        diagnostics = provider.lint(text)
+        loose = [d for d in diagnostics if d.code == RULE_CONV_THR_LOOSE]
+        assert loose == []
+
+    def test_very_loose_conv_thr(self, provider: LintProvider) -> None:
+        """conv_thr = 0.1 is clearly too loose."""
+        text = "&ELECTRONS\n  conv_thr = 0.1\n/\n"
+        diagnostics = provider.lint(text)
+        loose = [d for d in diagnostics if d.code == RULE_CONV_THR_LOOSE]
+        assert len(loose) == 1
+        assert "0.1" in loose[0].message
+
+    def test_snapshot_includes_conv_thr_warning(self, provider: LintProvider) -> None:
+        text = "&ELECTRONS\n  conv_thr = 1e-3\n/\n"
+        items = provider.snapshot(text)
+        loose_items = [i for i in items if i["code"] == RULE_CONV_THR_LOOSE]
+        assert len(loose_items) == 1
+        assert loose_items[0]["severity"] == "Warning"
 
 
 class TestLintSourceAndCode:

--- a/tests/fixtures/rules/conv_thr_loose.json
+++ b/tests/fixtures/rules/conv_thr_loose.json
@@ -1,0 +1,6 @@
+{
+  "rule_id": "qe.scf.conv_thr_loose",
+  "diagnostic_code": "QE-W010",
+  "severity": "warning",
+  "message_pattern": "conv_thr"
+}


### PR DESCRIPTION
Warns on loose conv_thr values (> 1e-4) in &ELECTRONS namelist. Fixes #63