### PR TITLE
feat: implement RULE qe.smearing.occupations_degauss_mismatch

### DIFF
--- a/src/qe_lsp/features/lint.py
+++ b/src/qe_lsp/features/lint.py
@@ -38,6 +38,7 @@ RULE_MISSING_CONTROL = "QE-E008"
 RULE_BAD_CALCULATION = "QE-E009"
 RULE_CONV_THR_LOOSE = "QE-W010"
 RULE_ECUTRHO_INCONSISTENT = "QE-W011"
+RULE_OCCUPATIONS_DEGAUSS_MISMATCH = "QE-W012"
 
 # ------------------------------------------------------------------
 # Schema data
@@ -366,6 +367,7 @@ class LintProvider:
         self._check_inconsistent_settings(parsed, diagnostics)
         self._check_conv_thr_loose(parsed, diagnostics)
         self._check_ecutrho_inconsistent(parsed, diagnostics)
+        self._check_occupations_degauss_mismatch(parsed, diagnostics)
         self._check_orphan_parameters(parsed, text, diagnostics)
 
         return diagnostics
@@ -711,6 +713,71 @@ class LintProvider:
                     ),
                     severity=DiagnosticSeverity.Warning,
                     code=RULE_ECUTRHO_INCONSISTENT,
+                )
+            )
+
+    def _check_occupations_degauss_mismatch(
+        self,
+        parsed: Any,
+        diagnostics: list[Diagnostic],
+    ) -> None:
+        """Emit QE-W012 when occupations='smearing' but degauss is missing or out of range."""
+        system = parsed.namelists.get("&SYSTEM", {})
+        occ_param = system.get("occupations")
+        if occ_param is None:
+            return
+
+        occ_value = normalize_value(occ_param.value)
+        if occ_value != "smearing":
+            return
+
+        degauss_param = system.get("degauss")
+        if degauss_param is None:
+            diagnostics.append(
+                self._make(
+                    line=occ_param.line,
+                    char=occ_param.character,
+                    length=len("occupations"),
+                    message=(
+                        "occupations = 'smearing' requires degauss in &SYSTEM, "
+                        "but degauss is not set."
+                    ),
+                    severity=DiagnosticSeverity.Warning,
+                    code=RULE_OCCUPATIONS_DEGAUSS_MISMATCH,
+                )
+            )
+            return
+
+        degauss_val = parse_number(degauss_param.value)
+        if degauss_val is None:
+            return
+
+        if degauss_val < 0.001:
+            diagnostics.append(
+                self._make(
+                    line=degauss_param.line,
+                    char=degauss_param.character,
+                    length=len("degauss"),
+                    message=(
+                        f"degauss = {degauss_val} is too small (< 0.001 Ry). "
+                        "Consider using a value >= 0.001 Ry for stable smearing."
+                    ),
+                    severity=DiagnosticSeverity.Warning,
+                    code=RULE_OCCUPATIONS_DEGAUSS_MISMATCH,
+                )
+            )
+        elif degauss_val > 0.1:
+            diagnostics.append(
+                self._make(
+                    line=degauss_param.line,
+                    char=degauss_param.character,
+                    length=len("degauss"),
+                    message=(
+                        f"degauss = {degauss_val} is too large (> 0.1 Ry). "
+                        "Consider using a value <= 0.1 Ry to avoid over-smearing."
+                    ),
+                    severity=DiagnosticSeverity.Warning,
+                    code=RULE_OCCUPATIONS_DEGAUSS_MISMATCH,
                 )
             )
 

--- a/tests/features/test_lint.py
+++ b/tests/features/test_lint.py
@@ -18,6 +18,7 @@ from qe_lsp.features.lint import (
     RULE_MISSING_CONTROL_CALC,
     RULE_MISSING_REQUIRED_SECTION,
     RULE_MISSING_SYSTEM_ECUTWFC,
+    RULE_OCCUPATIONS_DEGAUSS_MISMATCH,
     RULE_ORPHAN_PARAMETER,
     RULE_UNKNOWN_KEYWORD,
     RULE_UNKNOWN_NAMELIST,
@@ -552,3 +553,113 @@ class TestSnapshot:
         orphan_items = [i for i in items if i["code"] == RULE_ORPHAN_PARAMETER]
         assert len(orphan_items) >= 1
         assert orphan_items[0]["severity"] == "Warning"
+
+
+class TestOccupationsDegaussMismatch:
+    """RULE qe.smearing.occupations_degauss_mismatch (QE-W012): warn when
+    occupations='smearing' but degauss is missing or out of range."""
+
+    def test_missing_degauss_triggers_warning(self, provider: LintProvider) -> None:
+        text = (
+            "&SYSTEM\n"
+            "  occupations = 'smearing'\n"
+            "/\n"
+        )
+        diagnostics = provider.lint(text)
+        warnings = [d for d in diagnostics if d.code == RULE_OCCUPATIONS_DEGAUSS_MISMATCH]
+        assert len(warnings) == 1
+        assert "degauss is not set" in warnings[0].message
+        assert warnings[0].severity is not None
+        assert warnings[0].severity.value == 2  # Warning
+
+    def test_degauss_too_small_triggers_warning(self, provider: LintProvider) -> None:
+        text = (
+            "&SYSTEM\n"
+            "  occupations = 'smearing'\n"
+            "  degauss = 0.0001\n"
+            "/\n"
+        )
+        diagnostics = provider.lint(text)
+        warnings = [d for d in diagnostics if d.code == RULE_OCCUPATIONS_DEGAUSS_MISMATCH]
+        assert len(warnings) == 1
+        assert "too small" in warnings[0].message
+
+    def test_degauss_too_large_triggers_warning(self, provider: LintProvider) -> None:
+        text = (
+            "&SYSTEM\n"
+            "  occupations = 'smearing'\n"
+            "  degauss = 0.2\n"
+            "/\n"
+        )
+        diagnostics = provider.lint(text)
+        warnings = [d for d in diagnostics if d.code == RULE_OCCUPATIONS_DEGAUSS_MISMATCH]
+        assert len(warnings) == 1
+        assert "too large" in warnings[0].message
+
+    def test_valid_degauss_no_warning(self, provider: LintProvider) -> None:
+        text = (
+            "&SYSTEM\n"
+            "  occupations = 'smearing'\n"
+            "  degauss = 0.01\n"
+            "/\n"
+        )
+        diagnostics = provider.lint(text)
+        warnings = [d for d in diagnostics if d.code == RULE_OCCUPATIONS_DEGAUSS_MISMATCH]
+        assert warnings == []
+
+    def test_degauss_at_lower_bound_no_warning(self, provider: LintProvider) -> None:
+        """degauss = 0.001 exactly should NOT trigger the warning."""
+        text = (
+            "&SYSTEM\n"
+            "  occupations = 'smearing'\n"
+            "  degauss = 0.001\n"
+            "/\n"
+        )
+        diagnostics = provider.lint(text)
+        warnings = [d for d in diagnostics if d.code == RULE_OCCUPATIONS_DEGAUSS_MISMATCH]
+        assert warnings == []
+
+    def test_degauss_at_upper_bound_no_warning(self, provider: LintProvider) -> None:
+        """degauss = 0.1 exactly should NOT trigger the warning."""
+        text = (
+            "&SYSTEM\n"
+            "  occupations = 'smearing'\n"
+            "  degauss = 0.1\n"
+            "/\n"
+        )
+        diagnostics = provider.lint(text)
+        warnings = [d for d in diagnostics if d.code == RULE_OCCUPATIONS_DEGAUSS_MISMATCH]
+        assert warnings == []
+
+    def test_fixed_occupations_no_warning(self, provider: LintProvider) -> None:
+        """occupations = 'fixed' should not trigger degauss checks."""
+        text = (
+            "&SYSTEM\n"
+            "  occupations = 'fixed'\n"
+            "/\n"
+        )
+        diagnostics = provider.lint(text)
+        warnings = [d for d in diagnostics if d.code == RULE_OCCUPATIONS_DEGAUSS_MISMATCH]
+        assert warnings == []
+
+    def test_no_occupations_no_warning(self, provider: LintProvider) -> None:
+        """No occupations keyword at all should not trigger the check."""
+        text = (
+            "&SYSTEM\n"
+            "  ibrav = 1\n"
+            "/\n"
+        )
+        diagnostics = provider.lint(text)
+        warnings = [d for d in diagnostics if d.code == RULE_OCCUPATIONS_DEGAUSS_MISMATCH]
+        assert warnings == []
+
+    def test_snapshot_includes_degauss_warning(self, provider: LintProvider) -> None:
+        text = (
+            "&SYSTEM\n"
+            "  occupations = 'smearing'\n"
+            "/\n"
+        )
+        items = provider.snapshot(text)
+        degauss_items = [i for i in items if i["code"] == RULE_OCCUPATIONS_DEGAUSS_MISMATCH]
+        assert len(degauss_items) == 1
+        assert degauss_items[0]["severity"] == "Warning"

--- a/tests/fixtures/rules/occupations_degauss_mismatch.json
+++ b/tests/fixtures/rules/occupations_degauss_mismatch.json
@@ -1,0 +1,6 @@
+{
+  "rule_id": "qe.smearing.occupations_degauss_mismatch",
+  "diagnostic_code": "QE-W012",
+  "severity": "warning",
+  "message_pattern": "degauss"
+}


### PR DESCRIPTION
Warns when occupations=smearing but degauss is missing or unreasonable. Fixes #65