### PR TITLE
feat: implement RULE qe.kpoints.invalid_card

### DIFF
--- a/src/qe_lsp/features/lint.py
+++ b/src/qe_lsp/features/lint.py
@@ -39,6 +39,7 @@ RULE_BAD_CALCULATION = "QE-E009"
 RULE_CONV_THR_LOOSE = "QE-W010"
 RULE_ECUTRHO_INCONSISTENT = "QE-W011"
 RULE_OCCUPATIONS_DEGAUSS_MISMATCH = "QE-W012"
+RULE_INVALID_KPOINTS_CARD = "QE-E013"
 
 # ------------------------------------------------------------------
 # Schema data
@@ -310,6 +311,19 @@ VALID_CELL_DOFREE = frozenset(
     }
 )
 
+VALID_KPOINTS_TYPES = frozenset(
+    {
+        "tpiba",
+        "automatic",
+        "crystal",
+        "gamma",
+        "tpiba_b",
+        "crystal_b",
+        "tpiba_c",
+        "crystal_c",
+    }
+)
+
 #: Keyword -> (valid values, rule code for invalid value)
 VALUE_CONSTRAINTS: dict[str, tuple[frozenset[str], str]] = {
     "calculation": (VALID_CALCULATIONS, RULE_BAD_CALCULATION),
@@ -369,6 +383,7 @@ class LintProvider:
         self._check_ecutrho_inconsistent(parsed, diagnostics)
         self._check_occupations_degauss_mismatch(parsed, diagnostics)
         self._check_orphan_parameters(parsed, text, diagnostics)
+        self._check_invalid_kpoints_card(parsed, text, diagnostics)
 
         return diagnostics
 
@@ -815,6 +830,52 @@ class LintProvider:
                             code=RULE_ORPHAN_PARAMETER,
                         )
                     )
+
+    def _check_invalid_kpoints_card(
+        self,
+        parsed: Any,
+        text: str,
+        diagnostics: list[Diagnostic],
+    ) -> None:
+        """Emit QE-E013 when K_POINTS card has an invalid type specifier."""
+        import re
+
+        header = parsed.card_headers.get("K_POINTS")
+        if header is None:
+            return
+
+        # header is the full uppercase line, e.g. "K_POINTS {TPIBA}" or "K_POINTS"
+        match = re.match(r"K_POINTS\s*(?:\{(\w+)\})?", header)
+        if match is None:
+            return
+
+        card_type = match.group(1)
+        # K_POINTS without braces is valid (defaults to tpiba)
+        if card_type is None:
+            return
+
+        if card_type.lower() not in VALID_KPOINTS_TYPES:
+            # Find the line number for the K_POINTS card
+            kpoints_line = 0
+            for line_number, raw_line in enumerate(text.splitlines()):
+                upper = raw_line.upper().split()
+                if upper and upper[0] == "K_POINTS":
+                    kpoints_line = line_number
+                    break
+
+            diagnostics.append(
+                self._make(
+                    line=kpoints_line,
+                    char=0,
+                    length=len("K_POINTS"),
+                    message=(
+                        f"Invalid K_POINTS card type '{{{card_type}}}'. "
+                        f"Valid types: {', '.join(sorted(VALID_KPOINTS_TYPES))}."
+                    ),
+                    severity=DiagnosticSeverity.Error,
+                    code=RULE_INVALID_KPOINTS_CARD,
+                )
+            )
 
     # ------------------------------------------------------------------
     # Helpers

--- a/tests/features/test_lint.py
+++ b/tests/features/test_lint.py
@@ -11,6 +11,7 @@ from qe_lsp.features.lint import (
     RULE_DEPRECATED_KEYWORD,
     RULE_ECUTRHO_INCONSISTENT,
     RULE_INCONSISTENT_SETTINGS,
+    RULE_INVALID_KPOINTS_CARD,
     RULE_INVALID_KEYWORD_VALUE,
     RULE_MISSING_ATOMIC_POSITIONS,
     RULE_MISSING_ATOMIC_SPECIES,
@@ -663,3 +664,105 @@ class TestOccupationsDegaussMismatch:
         degauss_items = [i for i in items if i["code"] == RULE_OCCUPATIONS_DEGAUSS_MISMATCH]
         assert len(degauss_items) == 1
         assert degauss_items[0]["severity"] == "Warning"
+
+
+class TestInvalidKpointsCard:
+    """RULE qe.kpoints.invalid_card (QE-E013): error on invalid K_POINTS card type."""
+
+    def test_invalid_kpoints_type_triggers_error(self, provider: LintProvider) -> None:
+        text = (
+            "&CONTROL\n"
+            "  calculation = 'scf'\n"
+            "/\n"
+            "&SYSTEM\n"
+            "  ibrav = 1\n"
+            "  ecutwfc = 60\n"
+            "  nat = 1\n"
+            "  ntyp = 1\n"
+            "/\n"
+            "K_POINTS {bogus}\n"
+            "4 4 4 0 0 0\n"
+        )
+        diagnostics = provider.lint(text)
+        errors = [d for d in diagnostics if d.code == RULE_INVALID_KPOINTS_CARD]
+        assert len(errors) == 1
+        assert "BOGUS" in errors[0].message
+        assert errors[0].severity is not None
+        assert errors[0].severity.value == 1  # Error
+
+    def test_valid_kpoints_automatic_no_error(self, provider: LintProvider) -> None:
+        text = (
+            "&CONTROL\n"
+            "  calculation = 'scf'\n"
+            "/\n"
+            "&SYSTEM\n"
+            "  ibrav = 1\n"
+            "  ecutwfc = 60\n"
+            "  nat = 1\n"
+            "  ntyp = 1\n"
+            "/\n"
+            "K_POINTS {automatic}\n"
+            "4 4 4 0 0 0\n"
+        )
+        diagnostics = provider.lint(text)
+        errors = [d for d in diagnostics if d.code == RULE_INVALID_KPOINTS_CARD]
+        assert errors == []
+
+    def test_valid_kpoints_tpiba_no_error(self, provider: LintProvider) -> None:
+        text = "K_POINTS {tpiba}\n4\n  0.0 0.0 0.0 1.0\n"
+        diagnostics = provider.lint(text)
+        errors = [d for d in diagnostics if d.code == RULE_INVALID_KPOINTS_CARD]
+        assert errors == []
+
+    def test_valid_kpoints_crystal_no_error(self, provider: LintProvider) -> None:
+        text = "K_POINTS {crystal}\n4\n  0.0 0.0 0.0 1.0\n"
+        diagnostics = provider.lint(text)
+        errors = [d for d in diagnostics if d.code == RULE_INVALID_KPOINTS_CARD]
+        assert errors == []
+
+    def test_valid_kpoints_gamma_no_error(self, provider: LintProvider) -> None:
+        text = "K_POINTS {gamma}\n"
+        diagnostics = provider.lint(text)
+        errors = [d for d in diagnostics if d.code == RULE_INVALID_KPOINTS_CARD]
+        assert errors == []
+
+    def test_kpoints_without_braces_no_error(self, provider: LintProvider) -> None:
+        """K_POINTS without a type specifier defaults to tpiba and is valid."""
+        text = "K_POINTS\n4\n  0.0 0.0 0.0 1.0\n"
+        diagnostics = provider.lint(text)
+        errors = [d for d in diagnostics if d.code == RULE_INVALID_KPOINTS_CARD]
+        assert errors == []
+
+    def test_all_valid_types_no_error(self, provider: LintProvider) -> None:
+        """Every recognised K_POINTS type should be accepted."""
+        for ktype in ("tpiba", "automatic", "crystal", "gamma",
+                      "tpiba_b", "crystal_b", "tpiba_c", "crystal_c"):
+            text = f"K_POINTS {{{ktype}}}\n"
+            diagnostics = provider.lint(text)
+            errors = [d for d in diagnostics if d.code == RULE_INVALID_KPOINTS_CARD]
+            assert errors == [], f"K_POINTS {{{ktype}}} should be valid"
+
+    def test_snapshot_includes_kpoints_error(self, provider: LintProvider) -> None:
+        text = "K_POINTS {nonsense}\n4 4 4 0 0 0\n"
+        items = provider.snapshot(text)
+        kpoints_items = [i for i in items if i["code"] == RULE_INVALID_KPOINTS_CARD]
+        assert len(kpoints_items) == 1
+        assert kpoints_items[0]["severity"] == "Error"
+
+    def test_no_kpoints_card_no_error(self, provider: LintProvider) -> None:
+        """Input without K_POINTS should not trigger the check."""
+        text = (
+            "&CONTROL\n"
+            "  calculation = 'scf'\n"
+            "/\n"
+        )
+        diagnostics = provider.lint(text)
+        errors = [d for d in diagnostics if d.code == RULE_INVALID_KPOINTS_CARD]
+        assert errors == []
+
+    def test_case_insensitive_type(self, provider: LintProvider) -> None:
+        """K_POINTS type is stored uppercase by the parser; check should be case-insensitive."""
+        text = "K_POINTS {Automatic}\n4 4 4 0 0 0\n"
+        diagnostics = provider.lint(text)
+        errors = [d for d in diagnostics if d.code == RULE_INVALID_KPOINTS_CARD]
+        assert errors == []

--- a/tests/fixtures/rules/invalid_kpoints_card.json
+++ b/tests/fixtures/rules/invalid_kpoints_card.json
@@ -1,0 +1,6 @@
+{
+  "rule_id": "qe.kpoints.invalid_card",
+  "diagnostic_code": "QE-E013",
+  "severity": "error",
+  "message_pattern": "Invalid K_POINTS card type"
+}


### PR DESCRIPTION
Adds diagnostic for invalid K_POINTS card format in QE input. Closes #66

Valid K_POINTS types: tpiba, automatic, crystal, gamma, tpiba_b, crystal_b, tpiba_c, crystal_c.

Changes:
- Add RULE_INVALID_KPOINTS_CARD (QE-E013) constant
- Add VALID_KPOINTS_TYPES frozenset with all 8 valid types
- Add _check_invalid_kpoints_card method to LintProvider
- Add 10 tests covering valid types, invalid types, no-card case, and case-insensitive matching
- Add golden fixture tests/fixtures/rules/invalid_kpoints_card.json