### PR TITLE
feat(agent): expose domain language description API

### DIFF
--- a/src/qe_lsp/features/agent_api.py
+++ b/src/qe_lsp/features/agent_api.py
@@ -41,6 +41,287 @@ def _diag_to_dict(d: Diagnostic) -> Dict[str, Any]:
     }
 
 
+def describe_domain_language() -> Dict[str, Any]:
+    """Return a machine-readable description of the Quantum ESPRESSO input language.
+
+    The description includes supported namelists, common keywords with types
+    and short descriptions, recognised cards, and file extensions.  Agent
+    tools can call this at startup to bootstrap their understanding of the
+    QE domain.
+    """
+    return {
+        "language": "quantum-espresso",
+        "namelists": {
+            "CONTROL": {
+                "description": "General calculation control parameters.",
+                "keywords": {
+                    "calculation": {
+                        "type": "string",
+                        "enum": [
+                            "scf",
+                            "nscf",
+                            "bands",
+                            "relax",
+                            "md",
+                            "vc-relax",
+                            "vc-md",
+                        ],
+                        "description": "Type of calculation to perform.",
+                    },
+                    "prefix": {
+                        "type": "string",
+                        "description": "Prefix for output file names.",
+                    },
+                    "outdir": {
+                        "type": "string",
+                        "description": "Directory for temporary and output files.",
+                    },
+                    "pseudo_dir": {
+                        "type": "string",
+                        "description": "Directory containing pseudopotential files.",
+                    },
+                    "ibrav": {
+                        "type": "integer",
+                        "enum": list(range(0, 15)),
+                        "description": "Bravais-lattice index (0 = free).",
+                    },
+                    "restart_mode": {
+                        "type": "string",
+                        "enum": ["from_scratch", "restart"],
+                        "description": "Whether to restart from previous run.",
+                    },
+                    "tprnfor": {
+                        "type": "logical",
+                        "description": "Calculate forces.",
+                    },
+                    "tstress": {
+                        "type": "logical",
+                        "description": "Calculate stress tensor.",
+                    },
+                    "dt": {
+                        "type": "float",
+                        "description": "Time step for molecular dynamics (Ry*au).",
+                    },
+                    "max_seconds": {
+                        "type": "float",
+                        "description": "Wall-time limit in seconds.",
+                    },
+                    "etot_conv_thr": {
+                        "type": "float",
+                        "description": "Convergence threshold on total energy (Ry).",
+                    },
+                    "forc_conv_thr": {
+                        "type": "float",
+                        "description": "Convergence threshold on forces (Ry/au).",
+                    },
+                },
+            },
+            "SYSTEM": {
+                "description": "System-specific parameters.",
+                "keywords": {
+                    "celldm": {
+                        "type": "float[6]",
+                        "description": "Lattice parameters (celldm(1)-celldm(6)).",
+                    },
+                    "nat": {
+                        "type": "integer",
+                        "description": "Number of atoms in the unit cell.",
+                    },
+                    "ntyp": {
+                        "type": "integer",
+                        "description": "Number of atom types.",
+                    },
+                    "ecutwfc": {
+                        "type": "float",
+                        "description": "Kinetic-energy cutoff for wavefunctions (Ry).",
+                    },
+                    "ecutrho": {
+                        "type": "float",
+                        "description": "Kinetic-energy cutoff for charge density (Ry).",
+                    },
+                    "occupations": {
+                        "type": "string",
+                        "enum": ["smearing", "tetrahedra", "fixed", "from_input"],
+                        "description": "Occupation method.",
+                    },
+                    "degauss": {
+                        "type": "float",
+                        "description": "Smearing width (Ry).",
+                    },
+                    "smearing": {
+                        "type": "string",
+                        "enum": [
+                            "gaussian",
+                            "methfessel-paxton",
+                            "marzari-vanderbilt",
+                            "fd",
+                        ],
+                        "description": "Smearing type.",
+                    },
+                    "nspin": {
+                        "type": "integer",
+                        "enum": [1, 2, 4],
+                        "description": "Spin polarization (1=non-magnetic, 2=LSDA, 4=non-collinear).",
+                    },
+                    "noncolin": {
+                        "type": "logical",
+                        "description": "Non-collinear magnetism.",
+                    },
+                },
+            },
+            "ELECTRONS": {
+                "description": "Electronic-structure convergence parameters.",
+                "keywords": {
+                    "conv_thr": {
+                        "type": "float",
+                        "description": "Convergence threshold for SCF (Ry).",
+                    },
+                    "electron_maxstep": {
+                        "type": "integer",
+                        "description": "Maximum number of SCF iterations.",
+                    },
+                    "mixing_beta": {
+                        "type": "float",
+                        "description": "Mixing factor for self-consistency.",
+                    },
+                    "mixing_mode": {
+                        "type": "string",
+                        "enum": ["plain", "TF", "local-TF"],
+                        "description": "Charge-density mixing mode.",
+                    },
+                    "diagonalization": {
+                        "type": "string",
+                        "enum": ["david", "cg", "ppcg", "paro"],
+                        "description": "Eigenvalue solver.",
+                    },
+                    "scf_must_converge": {
+                        "type": "logical",
+                        "description": "Abort if SCF does not converge.",
+                    },
+                    "startingwfc": {
+                        "type": "string",
+                        "enum": ["random", "atomic", "atomic+random", "file"],
+                        "description": "Initial wavefunction guess.",
+                    },
+                    "startingcharge": {
+                        "type": "string",
+                        "enum": ["atomic", "file"],
+                        "description": "Initial charge-density guess.",
+                    },
+                },
+            },
+            "IONS": {
+                "description": "Ionic-motion parameters (relax / md).",
+                "keywords": {
+                    "ion_dynamics": {
+                        "type": "string",
+                        "enum": ["bfgs", "damp", "verlet", "langevin", "beeman"],
+                        "description": "Ionic dynamics algorithm.",
+                    },
+                    "ion_positions": {
+                        "type": "string",
+                        "enum": ["default", "from_input"],
+                        "description": "Source of initial ionic positions.",
+                    },
+                    "pot_extrapolation": {
+                        "type": "string",
+                        "enum": ["none", "atomic", "first_order", "second_order"],
+                        "description": "Potential extrapolation method.",
+                    },
+                    "bfgs_ndim": {
+                        "type": "integer",
+                        "description": "BFGS history dimension.",
+                    },
+                    "trust_radius_max": {
+                        "type": "float",
+                        "description": "Maximum trust radius (au).",
+                    },
+                    "trust_radius_min": {
+                        "type": "float",
+                        "description": "Minimum trust radius (au).",
+                    },
+                },
+            },
+            "CELL": {
+                "description": "Cell-motion parameters (vc-relax / vc-md).",
+                "keywords": {
+                    "cell_dynamics": {
+                        "type": "string",
+                        "enum": ["none", "sd", "damp-pr", "bfgs", "pr", "w"],
+                        "description": "Cell dynamics algorithm.",
+                    },
+                    "press": {
+                        "type": "float",
+                        "description": "Target pressure (kbar).",
+                    },
+                    "press_conv_thr": {
+                        "type": "float",
+                        "description": "Convergence threshold on pressure (kbar).",
+                    },
+                    "cell_factor": {
+                        "type": "float",
+                        "description": "Scaling factor for cell moves.",
+                    },
+                    "fix_volume": {
+                        "type": "logical",
+                        "description": "Keep cell volume fixed during relaxation.",
+                    },
+                    "fix_area": {
+                        "type": "logical",
+                        "description": "Keep cell area fixed (2D calculations).",
+                    },
+                },
+            },
+        },
+        "cards": {
+            "ATOMIC_SPECIES": {
+                "description": "Defines atom types and pseudopotentials.",
+                "syntax": "<type> <mass> <pseudo_file>",
+            },
+            "ATOMIC_POSITIONS": {
+                "description": "Coordinates of atoms in the unit cell.",
+                "options": ["alat", "bohr", "crystal", "angstrom", "crystal_sg"],
+            },
+            "K_POINTS": {
+                "description": "Brillouin-zone sampling.",
+                "options": [
+                    "tpiba",
+                    "automatic",
+                    "crystal",
+                    "gamma",
+                    "tpiba_b",
+                    "crystal_b",
+                ],
+            },
+            "CELL_PARAMETERS": {
+                "description": "Lattice vectors (when ibrav=0).",
+                "options": ["alat", "bohr", "angstrom"],
+            },
+            "ATOMIC_FORCES": {
+                "description": "External forces on atoms (for constrained optimisation).",
+                "syntax": "<index> <fx> <fy> <fz>",
+            },
+            "CONSTRAINTS": {
+                "description": "Geometric constraints on atoms.",
+            },
+            "OCCUPATIONS": {
+                "description": "Manual occupation numbers (when occupations='from_input').",
+            },
+        },
+        "file_types": {
+            ".in": "Primary Quantum ESPRESSO input file.",
+            ".pw": "PWscf input file alias.",
+            ".q2r": "q2r.x input (phonon interpolation).",
+            ".matdyn": "matdyn.x input (phonon dispersion).",
+            ".ph": "ph.x input (phonon calculation).",
+            ".pp": "pp.x input (post-processing).",
+            ".bands": "bands.x input (band structure).",
+            ".dos": "dos.x input (density of states).",
+            ".projwfc": "projwfc.x input (projected DOS).",
+        },
+    }
+
+
 class AgentAPIProvider:
     def __init__(self) -> None:
         pass

--- a/tests/features/test_agent_api.py
+++ b/tests/features/test_agent_api.py
@@ -1,6 +1,10 @@
 import json
 from lsprotocol.types import Diagnostic, DiagnosticSeverity, Position, Range
-from qe_lsp.features.agent_api import AgentAPIProvider, AgentAPISnapshot
+from qe_lsp.features.agent_api import (
+    AgentAPIProvider,
+    AgentAPISnapshot,
+    describe_domain_language,
+)
 
 
 class TestSnapshot:
@@ -38,3 +42,52 @@ class TestProvider:
     def test_diags_json(self):
         r = AgentAPIProvider().get_diagnostics_json("test")
         assert "count" in r
+
+
+class TestDescribeDomainLanguage:
+    def test_returns_dict_with_required_top_level_keys(self):
+        desc = describe_domain_language()
+        assert isinstance(desc, dict)
+        assert "namelists" in desc
+        assert "cards" in desc
+        assert "file_types" in desc
+        assert desc["language"] == "quantum-espresso"
+
+    def test_all_five_namelists_present(self):
+        desc = describe_domain_language()
+        namelists = desc["namelists"]
+        for name in ("CONTROL", "SYSTEM", "ELECTRONS", "IONS", "CELL"):
+            assert name in namelists, f"Missing namelist {name}"
+
+    def test_namelist_has_description_and_keywords(self):
+        desc = describe_domain_language()
+        for nl_name, nl in desc["namelists"].items():
+            assert "description" in nl, f"{nl_name} missing description"
+            assert "keywords" in nl, f"{nl_name} missing keywords"
+            for kw_name, kw in nl["keywords"].items():
+                assert "type" in kw, f"{nl_name}.{kw_name} missing type"
+                assert "description" in kw, f"{nl_name}.{kw_name} missing description"
+
+    def test_control_calculation_keyword_has_enum(self):
+        desc = describe_domain_language()
+        calc_kw = desc["namelists"]["CONTROL"]["keywords"]["calculation"]
+        assert "scf" in calc_kw["enum"]
+        assert "vc-relax" in calc_kw["enum"]
+
+    def test_cards_have_descriptions(self):
+        desc = describe_domain_language()
+        for card_name, card in desc["cards"].items():
+            assert "description" in card, f"{card_name} missing description"
+
+    def test_file_types_are_recognised_extensions(self):
+        desc = describe_domain_language()
+        assert ".in" in desc["file_types"]
+        assert ".pw" in desc["file_types"]
+
+    def test_return_value_is_fresh_copy(self):
+        a = describe_domain_language()
+        b = describe_domain_language()
+        a["namelists"]["CONTROL"]["keywords"]["calculation"]["enum"].append("bogus")
+        assert "bogus" not in describe_domain_language()["namelists"]["CONTROL"][
+            "keywords"
+        ]["calculation"]["enum"]


### PR DESCRIPTION
Adds `describe_domain_language()` for machine-readable QE input language descriptions.

## What it does

Returns a structured dict describing:
- **Namelists**: &CONTROL, &SYSTEM, &ELECTRONS, &IONS, &CELL with keywords, types, enums, and descriptions
- **Cards**: ATOMIC_SPECIES, ATOMIC_POSITIONS, K_POINTS, CELL_PARAMETERS, etc.
- **File types**: .in, .pw, .q2r, .matdyn, .ph, .pp, .bands, .dos, .projwfc

Agent tools can call this at startup to bootstrap their understanding of the QE domain.

## Tests

7 new tests covering:
- Top-level structure and required keys
- All five namelists present
- Keyword shape (type + description)
- Enum values for calculation
- Cards and file types
- Fresh-copy guarantee (mutations don't leak)

All 494 tests pass, 100% coverage.

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)