### PR TITLE
feat(agent): add section and keyword schema lookup

### DIFF
--- a/src/qe_lsp/features/agent_api.py
+++ b/src/qe_lsp/features/agent_api.py
@@ -322,6 +322,67 @@ def describe_domain_language() -> Dict[str, Any]:
     }
 
 
+def lookup_namelist(name: str) -> Optional[Dict[str, Any]]:
+    """Return schema for a QE namelist by name.
+
+    Returns a dict with:
+      - name: the namelist name (uppercased)
+      - description: short description of the namelist
+      - keywords: dict mapping keyword name to its schema (type, description,
+        default_value, valid_values, required)
+    Returns None if the namelist is not found.
+    """
+    domain = describe_domain_language()
+    nl = domain["namelists"].get(name.upper())
+    if nl is None:
+        return None
+    keywords: Dict[str, Any] = {}
+    for kw_name, kw_schema in nl["keywords"].items():
+        keywords[kw_name] = {
+            "type": kw_schema.get("type"),
+            "description": kw_schema.get("description", ""),
+            "default_value": kw_schema.get("default_value"),
+            "valid_values": kw_schema.get("enum"),
+            "required": kw_schema.get("required", False),
+        }
+    return {
+        "name": name.upper(),
+        "description": nl.get("description", ""),
+        "keywords": keywords,
+    }
+
+
+def lookup_keyword(namelist: str, keyword: str) -> Optional[Dict[str, Any]]:
+    """Return schema for a specific keyword within a namelist.
+
+    Returns a dict with:
+      - namelist: parent namelist name
+      - name: keyword name
+      - type: value type (string, integer, float, logical, etc.)
+      - description: short description
+      - default_value: default value if known, else None
+      - valid_values: list of valid values for enum types, else None
+      - required: whether this keyword is required
+    Returns None if the namelist or keyword is not found.
+    """
+    domain = describe_domain_language()
+    nl = domain["namelists"].get(namelist.upper())
+    if nl is None:
+        return None
+    kw_schema = nl["keywords"].get(keyword)
+    if kw_schema is None:
+        return None
+    return {
+        "namelist": namelist.upper(),
+        "name": keyword,
+        "type": kw_schema.get("type"),
+        "description": kw_schema.get("description", ""),
+        "default_value": kw_schema.get("default_value"),
+        "valid_values": kw_schema.get("enum"),
+        "required": kw_schema.get("required", False),
+    }
+
+
 class AgentAPIProvider:
     def __init__(self) -> None:
         pass

--- a/tests/features/test_agent_api.py
+++ b/tests/features/test_agent_api.py
@@ -4,6 +4,8 @@ from qe_lsp.features.agent_api import (
     AgentAPIProvider,
     AgentAPISnapshot,
     describe_domain_language,
+    lookup_keyword,
+    lookup_namelist,
 )
 
 
@@ -91,3 +93,109 @@ class TestDescribeDomainLanguage:
         assert "bogus" not in describe_domain_language()["namelists"]["CONTROL"][
             "keywords"
         ]["calculation"]["enum"]
+
+
+class TestLookupNamelist:
+    def test_returns_schema_for_control(self):
+        result = lookup_namelist("CONTROL")
+        assert result is not None
+        assert result["name"] == "CONTROL"
+        assert "description" in result
+        assert "keywords" in result
+        assert isinstance(result["keywords"], dict)
+
+    def test_case_insensitive_lookup(self):
+        result = lookup_namelist("control")
+        assert result is not None
+        assert result["name"] == "CONTROL"
+
+    def test_returns_none_for_unknown_namelist(self):
+        assert lookup_namelist("BOGUS") is None
+
+    def test_keyword_schemas_have_required_fields(self):
+        result = lookup_namelist("CONTROL")
+        assert result is not None
+        for kw_name, kw in result["keywords"].items():
+            assert "type" in kw, f"CONTROL.{kw_name} missing type"
+            assert "description" in kw, f"CONTROL.{kw_name} missing description"
+            assert "default_value" in kw, f"CONTROL.{kw_name} missing default_value"
+            assert "valid_values" in kw, f"CONTROL.{kw_name} missing valid_values"
+            assert "required" in kw, f"CONTROL.{kw_name} missing required"
+
+    def test_enum_keyword_has_valid_values(self):
+        result = lookup_namelist("CONTROL")
+        assert result is not None
+        calc_kw = result["keywords"]["calculation"]
+        assert calc_kw["valid_values"] is not None
+        assert "scf" in calc_kw["valid_values"]
+        assert "vc-relax" in calc_kw["valid_values"]
+
+    def test_non_enum_keyword_valid_values_is_none(self):
+        result = lookup_namelist("CONTROL")
+        assert result is not None
+        prefix_kw = result["keywords"]["prefix"]
+        assert prefix_kw["valid_values"] is None
+
+    def test_all_five_namelists_found(self):
+        for name in ("CONTROL", "SYSTEM", "ELECTRONS", "IONS", "CELL"):
+            result = lookup_namelist(name)
+            assert result is not None, f"Namelist {name} not found"
+            assert result["name"] == name
+
+
+class TestLookupKeyword:
+    def test_returns_schema_for_calculation(self):
+        result = lookup_keyword("CONTROL", "calculation")
+        assert result is not None
+        assert result["namelist"] == "CONTROL"
+        assert result["name"] == "calculation"
+        assert result["type"] == "string"
+        assert result["valid_values"] is not None
+        assert "scf" in result["valid_values"]
+
+    def test_case_insensitive_namelist(self):
+        result = lookup_keyword("system", "ecutwfc")
+        assert result is not None
+        assert result["namelist"] == "SYSTEM"
+        assert result["type"] == "float"
+
+    def test_returns_none_for_unknown_namelist(self):
+        assert lookup_keyword("BOGUS", "something") is None
+
+    def test_returns_none_for_unknown_keyword(self):
+        assert lookup_keyword("CONTROL", "nonexistent_keyword") is None
+
+    def test_non_enum_keyword_has_none_valid_values(self):
+        result = lookup_keyword("CONTROL", "prefix")
+        assert result is not None
+        assert result["valid_values"] is None
+        assert result["type"] == "string"
+
+    def test_enum_keyword_has_valid_values_list(self):
+        result = lookup_keyword("ELECTRONS", "diagonalization")
+        assert result is not None
+        assert result["valid_values"] is not None
+        assert "david" in result["valid_values"]
+        assert "cg" in result["valid_values"]
+
+    def test_logical_keyword(self):
+        result = lookup_keyword("CONTROL", "tprnfor")
+        assert result is not None
+        assert result["type"] == "logical"
+
+    def test_required_field_exists(self):
+        result = lookup_keyword("CONTROL", "calculation")
+        assert result is not None
+        assert "required" in result
+        assert isinstance(result["required"], bool)
+
+    def test_default_value_field_exists(self):
+        result = lookup_keyword("CONTROL", "calculation")
+        assert result is not None
+        assert "default_value" in result
+
+    def test_description_present(self):
+        result = lookup_keyword("SYSTEM", "ecutwfc")
+        assert result is not None
+        assert "description" in result
+        assert "cutoff" in result["description"].lower()

--- a/tests/fixtures/schema_lookup.json
+++ b/tests/fixtures/schema_lookup.json
@@ -1,0 +1,35 @@
+{
+  "capability_id": "qe.agent.schema_lookup",
+  "functions": [
+    {
+      "name": "lookup_namelist",
+      "description": "Return schema for a QE namelist by name",
+      "parameters": {
+        "name": "Namelist name (case-insensitive)"
+      },
+      "returns": "dict with name, description, keywords or None"
+    },
+    {
+      "name": "lookup_keyword",
+      "description": "Return schema for a specific keyword within a namelist",
+      "parameters": {
+        "namelist": "Parent namelist name (case-insensitive)",
+        "keyword": "Keyword name within the namelist"
+      },
+      "returns": "dict with namelist, name, type, description, default_value, valid_values, required or None"
+    }
+  ],
+  "sample_lookups": [
+    {
+      "namelist": "CONTROL",
+      "keyword": "calculation",
+      "expected_type": "string",
+      "expected_valid_values": ["scf", "nscf", "bands", "relax", "md", "vc-relax", "vc-md"]
+    },
+    {
+      "namelist": "SYSTEM",
+      "keyword": "ecutwfc",
+      "expected_type": "float"
+    }
+  ]
+}


### PR DESCRIPTION
Adds lookup_namelist() and lookup_keyword() for QE DSL authoring support.

## Changes
- `lookup_namelist(name)` returns schema for a QE namelist with all keywords, their types, descriptions, default values, valid values, and required flags
- `lookup_keyword(namelist, keyword)` returns schema for a specific keyword within a namelist
- Both functions are case-insensitive for namelist names
- Added comprehensive tests (17 new test cases)
- Added capability fixture `schema_lookup.json`

Fixes #51