### PR TITLE
feat: add QE output/log diagnostics

### DIFF
--- a/src/qe_lsp/features/test_runner.py
+++ b/src/qe_lsp/features/test_runner.py
@@ -56,14 +56,52 @@ _LINE_NUM_RE = re.compile(r"line\s+(\d+)", re.IGNORECASE)
 # ------------------------------------------------------------------
 
 RULE_SCF_NOT_CONVERGED = "QE-E014"
+RULE_ERROR_IN_ROUTINE = "QE-E015"
+RULE_QE_WARNING = "QE-E016"
+RULE_SEGMENTATION_FAULT = "QE-E017"
+RULE_MAX_CPU_TIME = "QE-E018"
+RULE_BAND_STRUCTURE_ERROR = "QE-E019"
+RULE_PHONON_ERROR = "QE-E020"
 
 #: Matches QE runtime log lines indicating SCF convergence failure.
-#: QE outputs forms like:
-#:
-#:   "SCF convergence NOT achieved after N iterations"
-#:   "convergence not achieved"
 _SCF_NOT_CONVERGED_RE = re.compile(
     r"convergence\s+(?:is\s+)?(?:NOT|not)\s+achieved",
+    re.IGNORECASE,
+)
+
+#: Matches QE "Error in routine <name>" lines.
+_ERROR_IN_ROUTINE_RE = re.compile(
+    r"Error in routine\s+(\S+)\s*(?:\(([^)]*)\))?\s*:\s*(.*)",
+    re.IGNORECASE,
+)
+
+#: Matches QE "WARNING:" lines.
+_QE_WARNING_RE = re.compile(
+    r"WARNING:\s*(.+)",
+    re.IGNORECASE,
+)
+
+#: Matches segfault lines.
+_SEGMENTATION_FAULT_RE = re.compile(
+    r"Segmentation\s+fault",
+    re.IGNORECASE,
+)
+
+#: Matches maximum CPU time exceeded.
+_MAX_CPU_TIME_RE = re.compile(
+    r"Maximum\s+CPU\s+time\s+exceeded",
+    re.IGNORECASE,
+)
+
+#: Matches band structure calculation errors.
+_BAND_STRUCTURE_ERROR_RE = re.compile(
+    r"(?:band\s+structure|bands)\s+(?:calculation\s+)?(?:error|fail)",
+    re.IGNORECASE,
+)
+
+#: Matches phonon calculation errors.
+_PHONON_ERROR_RE = re.compile(
+    r"(?:phonon|ph|lambda)\s+(?:calculation\s+)?(?:error|fail)",
     re.IGNORECASE,
 )
 
@@ -123,11 +161,15 @@ def solver_output_to_diagnostics(output: SolverOutput) -> List[Diagnostic]:
 def parse_log(log_text: str) -> List[Diagnostic]:
     """Parse QE runtime log output and return diagnostics for known issues.
 
-    Currently detects:
+    Detects the following patterns:
 
-    - **QE-E014** (``qe.log.scf_not_converged``): SCF convergence failure
-      indicated by lines containing "convergence NOT achieved" or
-      "convergence not achieved".
+    - **QE-E014** (``qe.log.scf_not_converged``): SCF convergence failure.
+    - **QE-E015** (``qe.log.error_in_routine``): Generic QE error in routine.
+    - **QE-E016** (``qe.log.warning``): QE WARNING lines.
+    - **QE-E017** (``qe.log.seg_fault``): Segmentation fault.
+    - **QE-E018** (``qe.log.max_cpu_time``): Maximum CPU time exceeded.
+    - **QE-E019** (``qe.log.band_structure_error``): Band structure errors.
+    - **QE-E020** (``qe.log.phonon_error``): Phonon calculation errors.
 
     Parameters
     ----------
@@ -160,7 +202,142 @@ def parse_log(log_text: str) -> List[Diagnostic]:
                 )
             )
 
+        match = _ERROR_IN_ROUTINE_RE.search(line)
+        if match:
+            routine = match.group(1)
+            detail = match.group(3) or match.group(2) or ""
+            diagnostics.append(
+                Diagnostic(
+                    range=Range(
+                        start=Position(line=line_number, character=0),
+                        end=Position(line=line_number, character=len(line)),
+                    ),
+                    message=(
+                        f"Error in routine '{routine}': {detail.strip()}. "
+                        f"Line: {line.strip()}"
+                    ),
+                    severity=DiagnosticSeverity.Error,
+                    source="qe-log-parser",
+                    code=RULE_ERROR_IN_ROUTINE,
+                )
+            )
+
+        match = _QE_WARNING_RE.search(line)
+        if match:
+            warning_text = match.group(1).strip()
+            diagnostics.append(
+                Diagnostic(
+                    range=Range(
+                        start=Position(line=line_number, character=0),
+                        end=Position(line=line_number, character=len(line)),
+                    ),
+                    message=f"QE WARNING: {warning_text}. Line: {line.strip()}",
+                    severity=DiagnosticSeverity.Warning,
+                    source="qe-log-parser",
+                    code=RULE_QE_WARNING,
+                )
+            )
+
+        if _SEGMENTATION_FAULT_RE.search(line):
+            diagnostics.append(
+                Diagnostic(
+                    range=Range(
+                        start=Position(line=line_number, character=0),
+                        end=Position(line=line_number, character=len(line)),
+                    ),
+                    message=(
+                        "Segmentation fault detected. "
+                        "Check memory allocation, input parameters, and compiler settings. "
+                        f"Line: {line.strip()}"
+                    ),
+                    severity=DiagnosticSeverity.Error,
+                    source="qe-log-parser",
+                    code=RULE_SEGMENTATION_FAULT,
+                )
+            )
+
+        if _MAX_CPU_TIME_RE.search(line):
+            diagnostics.append(
+                Diagnostic(
+                    range=Range(
+                        start=Position(line=line_number, character=0),
+                        end=Position(line=line_number, character=len(line)),
+                    ),
+                    message=(
+                        "Maximum CPU time exceeded. "
+                        "Consider reducing system size, using fewer k-points, "
+                        "or adjusting calculation parameters. "
+                        f"Line: {line.strip()}"
+                    ),
+                    severity=DiagnosticSeverity.Error,
+                    source="qe-log-parser",
+                    code=RULE_MAX_CPU_TIME,
+                )
+            )
+
+        if _BAND_STRUCTURE_ERROR_RE.search(line):
+            diagnostics.append(
+                Diagnostic(
+                    range=Range(
+                        start=Position(line=line_number, character=0),
+                        end=Position(line=line_number, character=len(line)),
+                    ),
+                    message=(
+                        "Band structure calculation error. "
+                        "Check k-point path, occupations, and symmetry settings. "
+                        f"Line: {line.strip()}"
+                    ),
+                    severity=DiagnosticSeverity.Error,
+                    source="qe-log-parser",
+                    code=RULE_BAND_STRUCTURE_ERROR,
+                )
+            )
+
+        if _PHONON_ERROR_RE.search(line):
+            diagnostics.append(
+                Diagnostic(
+                    range=Range(
+                        start=Position(line=line_number, character=0),
+                        end=Position(line=line_number, character=len(line)),
+                    ),
+                    message=(
+                        "Phonon calculation error. "
+                        "Check q-point grid, dynamical matrix, and force convergence. "
+                        f"Line: {line.strip()}"
+                    ),
+                    severity=DiagnosticSeverity.Error,
+                    source="qe-log-parser",
+                    code=RULE_PHONON_ERROR,
+                )
+            )
+
     return diagnostics
+
+
+def parse_qe_output(path: Path) -> List[Diagnostic]:
+    """Read a QE output/log file from disk and return diagnostics.
+
+    This is a convenience wrapper around :func:`parse_log` intended for
+    CLI and agent consumers that have a file path rather than in-memory
+    text.
+
+    Parameters
+    ----------
+    path:
+        Path to a QE output or log file (e.g. ``pw.out``, ``ph.out``).
+
+    Returns
+    -------
+    list[Diagnostic]
+        LSP diagnostics for every detected issue in the file.
+
+    Raises
+    ------
+    FileNotFoundError
+        If *path* does not exist.
+    """
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return parse_log(text)
 
 
 class TestRunnerProvider:

--- a/tests/features/test_test_runner.py
+++ b/tests/features/test_test_runner.py
@@ -3,12 +3,21 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from lsprotocol.types import DiagnosticSeverity
 from qe_lsp.features.test_runner import (
+    RULE_BAND_STRUCTURE_ERROR,
+    RULE_ERROR_IN_ROUTINE,
+    RULE_MAX_CPU_TIME,
+    RULE_PHONON_ERROR,
+    RULE_QE_WARNING,
     RULE_SCF_NOT_CONVERGED,
+    RULE_SEGMENTATION_FAULT,
     TestRunnerConfig,
     TestRunnerProvider,
     parse_log,
+    parse_qe_output,
     parse_solver_output,
     solver_output_to_diagnostics,
     SolverOutput,
@@ -190,3 +199,261 @@ class TestParseLogSCFNotConverged:
         assert data["diagnostic_code"] == RULE_SCF_NOT_CONVERGED
         assert data["severity"] == "error"
         assert "SCF convergence" in data["message_pattern"]
+
+
+class TestParseLogErrorInRoutine:
+    """RULE qe.log.error_in_routine (QE-E015): generic QE error in routine."""
+
+    def test_error_in_routine_basic(self) -> None:
+        """Standard 'Error in routine' line."""
+        log = "     Error in routine pwscf (某某): some error description\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_ERROR_IN_ROUTINE]
+        assert len(errors) == 1
+        assert errors[0].severity == DiagnosticSeverity.Error
+        assert errors[0].source == "qe-log-parser"
+        assert "pwscf" in errors[0].message
+
+    def test_error_in_routine_no_parens(self) -> None:
+        """Error in routine without parenthetical detail."""
+        log = "Error in routine c_phagsi: problems computing eigenvectors\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_ERROR_IN_ROUTINE]
+        assert len(errors) == 1
+        assert "c_phagsi" in errors[0].message
+
+    def test_error_in_routine_with_detail(self) -> None:
+        """Error in routine with colon-separated detail."""
+        log = "Error in routine punch_plot (WRITE): error writing to file\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_ERROR_IN_ROUTINE]
+        assert len(errors) == 1
+        assert "punch_plot" in errors[0].message
+
+    def test_no_false_positive(self) -> None:
+        """Normal output should not trigger."""
+        log = "     routine pwscf finished successfully\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_ERROR_IN_ROUTINE]
+        assert errors == []
+
+    def test_line_number_correct(self) -> None:
+        """Error on third line gets line number 2."""
+        log = "line 0\nline 1\nError in routine pwscf: bad\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_ERROR_IN_ROUTINE]
+        assert len(errors) == 1
+        assert errors[0].range.start.line == 2
+
+
+class TestParseLogQEWarning:
+    """RULE qe.log.warning (QE-E016): QE WARNING lines."""
+
+    def test_warning_basic(self) -> None:
+        """Standard WARNING: line."""
+        log = "WARNING: degenerate or nearly degenerate eigenvalues found\n"
+        diags = parse_log(log)
+        warnings = [d for d in diags if d.code == RULE_QE_WARNING]
+        assert len(warnings) == 1
+        assert warnings[0].severity == DiagnosticSeverity.Warning
+        assert warnings[0].source == "qe-log-parser"
+        assert "degenerate" in warnings[0].message
+
+    def test_warning_mixed_case(self) -> None:
+        """Mixed-case warning should still match."""
+        log = "Warning: something went wrong\n"
+        diags = parse_log(log)
+        warnings = [d for d in diags if d.code == RULE_QE_WARNING]
+        assert len(warnings) == 1
+
+    def test_no_false_positive(self) -> None:
+        """Normal output without WARNING: should not trigger."""
+        log = "     calculation finished without issues\n"
+        diags = parse_log(log)
+        warnings = [d for d in diags if d.code == RULE_QE_WARNING]
+        assert warnings == []
+
+    def test_multiple_warnings(self) -> None:
+        """Multiple WARNING lines produce multiple diagnostics."""
+        log = (
+            "WARNING: first warning\n"
+            "some output\n"
+            "WARNING: second warning\n"
+        )
+        diags = parse_log(log)
+        warnings = [d for d in diags if d.code == RULE_QE_WARNING]
+        assert len(warnings) == 2
+        assert warnings[0].range.start.line == 0
+        assert warnings[1].range.start.line == 2
+
+
+class TestParseLogSegfault:
+    """RULE qe.log.seg_fault (QE-E017): Segmentation fault."""
+
+    def test_segfault(self) -> None:
+        log = "Segmentation fault\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_SEGMENTATION_FAULT]
+        assert len(errors) == 1
+        assert errors[0].severity == DiagnosticSeverity.Error
+        assert "Segmentation fault" in errors[0].message
+
+    def test_segfault_in_context(self) -> None:
+        log = (
+            "Program PWSCF v.7.2 starts\n"
+            "some computation\n"
+            "Segmentation fault (core dumped)\n"
+        )
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_SEGMENTATION_FAULT]
+        assert len(errors) == 1
+        assert errors[0].range.start.line == 2
+
+    def test_no_false_positive(self) -> None:
+        log = "     computation completed successfully\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_SEGMENTATION_FAULT]
+        assert errors == []
+
+
+class TestParseLogMaxCPUTime:
+    """RULE qe.log.max_cpu_time (QE-E018): Maximum CPU time exceeded."""
+
+    def test_max_cpu_time(self) -> None:
+        log = "Maximum CPU time exceeded\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_MAX_CPU_TIME]
+        assert len(errors) == 1
+        assert errors[0].severity == DiagnosticSeverity.Error
+
+    def test_max_cpu_time_with_detail(self) -> None:
+        log = (
+            "     WARNING: Maximum CPU time exceeded in scf cycle\n"
+        )
+        diags = parse_log(log)
+        max_cpu = [d for d in diags if d.code == RULE_MAX_CPU_TIME]
+        assert len(max_cpu) == 1
+
+    def test_no_false_positive(self) -> None:
+        log = "     CPU time: 12.5 seconds\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_MAX_CPU_TIME]
+        assert errors == []
+
+
+class TestParseLogBandStructureError:
+    """RULE qe.log.band_structure_error (QE-E019): band structure errors."""
+
+    def test_band_structure_error(self) -> None:
+        log = "band structure calculation error\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_BAND_STRUCTURE_ERROR]
+        assert len(errors) == 1
+        assert errors[0].severity == DiagnosticSeverity.Error
+
+    def test_bands_fail(self) -> None:
+        log = "     bands error during interpolation\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_BAND_STRUCTURE_ERROR]
+        assert len(errors) == 1
+
+    def test_band_structure_fail(self) -> None:
+        log = "band structure calculation fail\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_BAND_STRUCTURE_ERROR]
+        assert len(errors) == 1
+
+    def test_no_false_positive(self) -> None:
+        log = "     band structure computed successfully\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_BAND_STRUCTURE_ERROR]
+        assert errors == []
+
+
+class TestParseLogPhononError:
+    """RULE qe.log.phonon_error (QE-E020): phonon calculation errors."""
+
+    def test_phonon_error(self) -> None:
+        log = "phonon calculation error\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_PHONON_ERROR]
+        assert len(errors) == 1
+        assert errors[0].severity == DiagnosticSeverity.Error
+
+    def test_ph_error(self) -> None:
+        log = "     ph calculation error in q-point\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_PHONON_ERROR]
+        assert len(errors) == 1
+
+    def test_lambda_error(self) -> None:
+        log = "lambda calculation error\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_PHONON_ERROR]
+        assert len(errors) == 1
+
+    def test_phonon_fail(self) -> None:
+        log = "phonon calculation fail\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_PHONON_ERROR]
+        assert len(errors) == 1
+
+    def test_no_false_positive(self) -> None:
+        log = "     phonon frequencies computed successfully\n"
+        diags = parse_log(log)
+        errors = [d for d in diags if d.code == RULE_PHONON_ERROR]
+        assert errors == []
+
+
+class TestParseLogMixed:
+    """Multiple error types in the same log produce multiple diagnostics."""
+
+    def test_mixed_errors(self) -> None:
+        log = (
+            "WARNING: something suspicious\n"
+            "SCF convergence NOT achieved after 100 iterations\n"
+            "Error in routine pwscf: bad input\n"
+            "Segmentation fault\n"
+        )
+        diags = parse_log(log)
+        codes = [d.code for d in diags]
+        assert RULE_QE_WARNING in codes
+        assert RULE_SCF_NOT_CONVERGED in codes
+        assert RULE_ERROR_IN_ROUTINE in codes
+        assert RULE_SEGMENTATION_FAULT in codes
+        assert len(diags) == 4
+
+
+class TestParseQEOutput:
+    """Tests for parse_qe_output file-based function."""
+
+    def test_reads_file_and_parses(self, tmp_path: Path) -> None:
+        """parse_qe_output reads a file and returns diagnostics."""
+        log_file = tmp_path / "pw.out"
+        log_file.write_text("SCF convergence NOT achieved after 50 iterations\n")
+        diags = parse_qe_output(log_file)
+        assert len(diags) == 1
+        assert diags[0].code == RULE_SCF_NOT_CONVERGED
+
+    def test_clean_file_no_diagnostics(self, tmp_path: Path) -> None:
+        """Clean output produces no diagnostics."""
+        log_file = tmp_path / "pw.out"
+        log_file.write_text("     Program PWSCF v.7.2 starts\n     convergence achieved\n")
+        diags = parse_qe_output(log_file)
+        assert diags == []
+
+    def test_file_not_found(self) -> None:
+        """Raises FileNotFoundError for missing file."""
+        with pytest.raises(FileNotFoundError):
+            parse_qe_output(Path("/no/such/file.out"))
+
+    def test_multi_pattern_file(self, tmp_path: Path) -> None:
+        """File with multiple errors produces multiple diagnostics."""
+        log_file = tmp_path / "pw.out"
+        log_file.write_text(
+            "WARNING: something\n"
+            "Error in routine pwscf: bad\n"
+            "Segmentation fault\n"
+        )
+        diags = parse_qe_output(log_file)
+        assert len(diags) == 3


### PR DESCRIPTION
Enhances log parser with comprehensive QE output patterns including:

- QE-E015: Error in routine (generic QE errors)
- QE-E016: WARNING lines
- QE-E017: Segmentation fault
- QE-E018: Maximum CPU time exceeded
- QE-E019: Band structure calculation errors
- QE-E020: Phonon calculation errors

Also adds `parse_qe_output(path)` public function for CLI/agent use.

All 549 tests pass with 100% coverage on changed code.

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)