### PR TITLE
docs: close out LLM wiki raw collection (issue #87)

### DIFF
--- a/docs/LLM-WIKI-PLAN.md
+++ b/docs/LLM-WIKI-PLAN.md
@@ -183,7 +183,17 @@ The wiki covers:
 4. ✅ Create concept pages (5)
 5. ✅ Create synthesis pages (7)
 6. ✅ Create index.md and log.md
-7. ⏭️ Git commit and PR
+7. ✅ Git commit and PR
+8. ✅ Closeout pass (issue #87): upstream manifest, example input, LSP provenance, wiki lint
+
+## Closeout Status (issue #87)
+
+- [x] Upstream QE documentation link manifest (`raw/assets/upstream-qe-reference.md`)
+- [x] Official test-suite example input (`raw/assets/example-carbonyl-relax.in`)
+- [x] Cross-references in `index.md` (OpenQC agent context, upstream manifest)
+- [x] Lightweight wiki lint (`scripts/wiki-lint.sh`)
+- [x] LSP source provenance in `lsp-capabilities.json` (expanded 1→6 entries)
+- [x] OpenQC agent context grounding (`wiki/synthesis/openqc-agent-context.md`)
 
 ## Git Workflow / Git 工作流
 

--- a/index.md
+++ b/index.md
@@ -78,12 +78,15 @@ log.md        # Change log
 - [Programs Reference](wiki/synthesis/programs-reference.md) - All QE programs
 - [Pseudopotential Reference](wiki/synthesis/pseudopotential-reference.md) - PP types, libraries, formats
 - [Examples Reference](wiki/synthesis/examples-reference.md) - Input file examples for all calculation types
+- [OpenQC Agent Context](wiki/synthesis/openqc-agent-context.md) - LSP capability and evidence mapping
 
 ### 原始文档 / Raw Documentation
 
+- [Upstream QE Reference](raw/assets/upstream-qe-reference.md) - Official documentation link manifest
 - [pw.x Input Reference](raw/assets/qe-pw-input-reference.md) - Complete pw.x parameter reference
 - [Programs Reference](raw/assets/qe-programs-reference.md) - All QE program input formats
 - [Example Inputs](raw/assets/qe-examples.md) - Annotated examples (SCF, NSCF, bands, relax, MD, phonon)
+- [CO Relax Example](raw/assets/example-carbonyl-relax.in) - Official test-suite relax input
 - [Output Format](raw/assets/qe-output-format.md) - QE output file format and parsing
 - [Pseudopotentials](raw/assets/qe-pseudopotentials.md) - PP formats, libraries, and usage
 

--- a/log.md
+++ b/log.md
@@ -6,6 +6,30 @@ This log tracks all changes to the QE-LSP LLM Wiki.
 
 ## 2026-06-13 / 2026年6月13日
 
+### Closeout Pass (issue #87) / 收尾工作
+
+Completed remaining upstream documentation coverage, example inputs, cross-references, and LSP-facing updates.
+
+#### Raw Documentation (2 new files) / 原始文档（2 个新文件）
+
+1. [upstream-qe-reference.md](raw/assets/upstream-qe-reference.md) - Official QE documentation link manifest
+2. [example-carbonyl-relax.in](raw/assets/example-carbonyl-relax.in) - CO relax input from official QE test suite
+
+#### LSP Surface Updates / LSP 表面更新
+
+3. [lsp-capabilities.json](lsp-capabilities.json) - sourceProvenance expanded 1→6 entries
+4. [openqc-agent-context.md](wiki/synthesis/openqc-agent-context.md) - Capability-to-evidence table and example references
+
+#### Navigation and Tooling / 导航与工具
+
+5. [index.md](index.md) - Added upstream manifest, OpenQC agent context, CO relax example
+6. [scripts/wiki-lint.sh](scripts/wiki-lint.sh) - Lightweight orphan/broken-link check
+7. [docs/LLM-WIKI-PLAN.md](docs/LLM-WIKI-PLAN.md) - Closeout checklist recorded
+
+---
+
+## 2026-06-13 / 2026年6月13日
+
 ### Documentation Collection Expansion / 文档收集扩展
 
 Expanded the wiki with comprehensive upstream Quantum ESPRESSO documentation collected from official sources.

--- a/lsp-capabilities.json
+++ b/lsp-capabilities.json
@@ -93,6 +93,31 @@
       "kind": "official_docs",
       "label": "Quantum ESPRESSO input descriptions",
       "url": "https://www.quantum-espresso.org/documentation/input-data-description/"
+    },
+    {
+      "kind": "official_spec",
+      "label": "pw.x input reference",
+      "url": "https://www.quantum-espresso.org/Doc/INPUT_PW.html"
+    },
+    {
+      "kind": "official_spec",
+      "label": "ph.x input reference",
+      "url": "https://www.quantum-espresso.org/Doc/INPUT_PH.html"
+    },
+    {
+      "kind": "official_tutorial",
+      "label": "QE hands-on DOS tutorial",
+      "url": "https://pranabdas.github.io/espresso/hands-on/dos/"
+    },
+    {
+      "kind": "official_docs",
+      "label": "QE pseudopotential libraries",
+      "url": "https://www.quantum-espresso.org/pseudopotentials/"
+    },
+    {
+      "kind": "upstream_manifest",
+      "label": "Upstream QE reference links",
+      "path": "raw/assets/upstream-qe-reference.md"
     }
   ]
 }

--- a/raw/assets/example-carbonyl-relax.in
+++ b/raw/assets/example-carbonyl-relax.in
@@ -1,0 +1,27 @@
+! CO relaxation example from the official QE test suite.
+! Upstream: https://github.com/QEF/q-e/blob/0f3d9044f2e553b900550e8f0f18b3cb416f13b6/test-suite/pw_relax/relax.in
+! See also: raw/assets/qe-examples.md, wiki/synthesis/examples-reference.md
+
+&CONTROL
+  calculation  = "relax"
+/
+&SYSTEM
+  ibrav     = 1,
+  celldm(1) =12.0,
+  nat       = 2,
+  ntyp      = 2,
+  ecutwfc   = 24.D0,
+  ecutrho   = 144.D0,
+/
+&ELECTRONS
+  conv_thr  = 1.0e-7
+/
+&IONS
+/
+ATOMIC_SPECIES
+O  1.00  O.pz-rrkjus.UPF
+C  1.00  C.pz-rrkjus.UPF
+ATOMIC_POSITIONS {bohr}
+C  2.256  0.0  0.0
+O  0.000  0.0  0.0  0 0 0
+K_POINTS {Gamma}

--- a/raw/assets/upstream-qe-reference.md
+++ b/raw/assets/upstream-qe-reference.md
@@ -1,0 +1,49 @@
+# Upstream Quantum ESPRESSO Reference Links (QE 上游参考链接)
+
+**Purpose**: Concise manifest of official Quantum ESPRESSO documentation sources for LLM wiki evidence.
+**Do not duplicate content**; link to canonical upstream resources.
+
+## Official Input References
+
+| Program | URL | Description |
+|---------|-----|-------------|
+| pw.x (plane-wave) | https://www.quantum-espresso.org/Doc/INPUT_PW.html | Complete pw.x namelist and card reference |
+| cp.x (Car-Parrinello) | https://www.quantum-espresso.org/Doc/INPUT_CP.html | CP molecular dynamics input |
+| ph.x (phonons) | https://www.quantum-espresso.org/Doc/INPUT_PH.html | DFPT phonon calculations |
+| pp.x (post-processing) | https://www.quantum-espresso.org/Doc/INPUT_PP.html | Post-processing utilities |
+| projwfc.x | https://www.quantum-espresso.org/Doc/INPUT_PROJWFC.html | Projected wavefunctions and DOS |
+| Input data overview | https://www.quantum-espresso.org/documentation/input-data-description/ | General input file structure |
+
+## Pseudopotentials and Libraries
+
+| Resource | URL | Description |
+|----------|-----|-------------|
+| Pseudopotential portal | https://www.quantum-espresso.org/pseudopotentials/ | Official PP libraries and formats |
+| SSSP library | https://www.materialscloud.org/discover/sssp | Standard solid-state pseudopotentials |
+| PSlibrary | https://www.quantum-espresso.org/pseudopotentials/ps-library | PBE and PBEsol libraries |
+
+## Tutorials and Examples
+
+| Tutorial | URL | Notes |
+|----------|-----|-------|
+| QE hands-on DOS | https://pranabdas.github.io/espresso/hands-on/dos/ | Density of states workflow |
+| QE test suite (GitHub) | https://github.com/QEF/q-e/tree/develop/test-suite | Official regression inputs |
+| Non-SCF calculations wiki | https://wiki.max-centre.eu/index.php/Non_self-consistent_calculations | NSCF and bands setup |
+
+## Output and Post-Processing
+
+| Resource | URL | Description |
+|----------|-----|-------------|
+| QE output parsing guide | https://blog.levilentz.com/parse-quantum-espresso-output-file/ | stdout markers and data extraction |
+| QE documentation index | https://www.quantum-espresso.org/documentation/ | Full documentation hub |
+
+## Developer / Source
+
+| Resource | URL | Notes |
+|----------|-----|-------|
+| QE GitHub (QEF) | https://github.com/QEF/q-e | Official source repository |
+| QE releases | https://www.quantum-espresso.org/download/ | Version downloads |
+
+---
+*Manifest created: 2026-06-13*
+*Evidence for issue #87: upstream documentation coverage gap fill*

--- a/scripts/wiki-lint.sh
+++ b/scripts/wiki-lint.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# wiki-lint.sh — lightweight LLM-wiki lint for qe-lsp
+# Checks for orphan pages, broken internal links, and missing index references.
+set -euo pipefail
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+errors=0
+
+echo "=== LLM Wiki Lint: qe-lsp ==="
+
+wiki_files=()
+while IFS= read -r f; do
+  wiki_files+=("$f")
+done < <(find "$repo_root/wiki" -name "*.md" -type f 2>/dev/null | sort)
+
+echo "Found ${#wiki_files[@]} wiki pages"
+
+index="$repo_root/index.md"
+for f in "${wiki_files[@]}"; do
+  basename_f="$(basename "$f" .md)"
+  if ! grep -q "$basename_f" "$index" 2>/dev/null; then
+    echo "WARN: $basename_f not referenced in index.md"
+  fi
+done
+
+broken=0
+for f in "${wiki_files[@]}"; do
+  dir="$(dirname "$f")"
+  while IFS= read -r link; do
+    target="$dir/$link"
+    if [ ! -f "$target" ]; then
+      echo "BROKEN LINK: $f -> $link"
+      broken=$((broken + 1))
+      errors=$((errors + 1))
+    fi
+  done < <(grep -oP '\]\(\K[^)]+(?=\))' "$f" 2>/dev/null | grep '\.md' | head -20 || true)
+done
+echo "Internal link check: $broken broken links"
+
+raw_count=$(find "$repo_root/raw/assets" -type f \( -name "*.md" -o -name "*.in" \) 2>/dev/null | wc -l | tr -d ' ')
+echo "Raw asset files (md/in): $raw_count"
+
+if [ "$errors" -gt 0 ]; then
+  echo "RESULT: $errors issue(s) found"
+  exit 1
+else
+  echo "RESULT: All checks passed"
+  exit 0
+fi

--- a/src/qe_lsp/tool.py
+++ b/src/qe_lsp/tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from .agent_operations import operation_path, with_capabilities
 from .rich_diagnostics import agent_check_payload
@@ -17,7 +17,7 @@ def _capabilities_payload() -> dict[str, Any]:
     for parent in Path(__file__).resolve().parents:
         manifest_path = parent / "lsp-capabilities.json"
         if manifest_path.exists():
-            return json.loads(manifest_path.read_text(encoding="utf-8"))
+            return cast(dict[str, Any], json.loads(manifest_path.read_text(encoding="utf-8")))
     return {
         "schema": "OpenQCLspCapabilities",
         "version": 1,

--- a/src/qe_lsp/tool.py
+++ b/src/qe_lsp/tool.py
@@ -33,7 +33,15 @@ def _capabilities_payload() -> dict[str, Any]:
             "openqc-context",
         ],
         "agentCli": {
-            "operations": ["capabilities", "check", "context", "complete", "hover", "symbols", "fix"],
+            "operations": [
+                "capabilities",
+                "check",
+                "context",
+                "complete",
+                "hover",
+                "symbols",
+                "fix",
+            ],
             "jsonFormat": True,
             "failOnBlocking": True,
         },

--- a/wiki/synthesis/openqc-agent-context.md
+++ b/wiki/synthesis/openqc-agent-context.md
@@ -1,3 +1,42 @@
 # OpenQC Agent Context
 
 OpenQC consumes `qe-lsp-tool` and `lsp-capabilities.json` to assemble diagnostics, hover, completion, symbols, examples, next-token guidance, and repair-plan hints for `qe` documents.
+
+## LSP Capability Surface
+
+| Capability | Operation | Source Evidence |
+|------------|-----------|-----------------|
+| Completion | `complete` | Namelist/card keywords from [completion.py](../../raw/assets/constants.py); see [Quick Reference](./quick-reference.md) |
+| Hover | `hover` | Parameter docs from [hover.py](../../src/qe_lsp/handlers/hover.py); namelist refs in [control-namelist-reference.md](./control-namelist-reference.md) |
+| Diagnostics | `check` | Validation from [validation.py](../../raw/assets/validation.py), lint from [lint.py](../../src/qe_lsp/features/lint.py); [Diagnostic Engine](../concepts/diagnostic-engine-v1.md) |
+| Symbols | `symbols` | Namelist/card outline from document symbol handler |
+| Fix Preview | `fix` | Code actions from validation and lint rules |
+| Navigation | `definition` | Go-to-definition for namelists and cards |
+| Blocking Gate | `check` | Warning-only by default (`blockingPolicy.mode: warning-only` in `lsp-capabilities.json`) |
+
+## Source Provenance
+
+The LSP draws domain knowledge from these upstream sources (recorded in `lsp-capabilities.json` → `sourceProvenance`):
+
+- **QE input descriptions**: https://www.quantum-espresso.org/documentation/input-data-description/
+- **pw.x reference**: https://www.quantum-espresso.org/Doc/INPUT_PW.html
+- **ph.x reference**: https://www.quantum-espresso.org/Doc/INPUT_PH.html
+- **DOS tutorial**: https://pranabdas.github.io/espresso/hands-on/dos/
+- **Pseudopotential libraries**: https://www.quantum-espresso.org/pseudopotentials/
+- **Upstream manifest**: [raw/assets/upstream-qe-reference.md](../../raw/assets/upstream-qe-reference.md)
+
+## Diagnostic Engine
+
+Diagnostics follow `DiagnosticEnvelope/v1` (see `diagnostics/diagnostic-engine-v1.schema.json`). Default blocking policy is `warning-only`.
+
+## Example Inputs
+
+- **Silicon SCF**: [raw/assets/silicon_scf.in](../../raw/assets/silicon_scf.in) — basic SCF calculation
+- **CO relax (official test suite)**: [raw/assets/example-carbonyl-relax.in](../../raw/assets/example-carbonyl-relax.in) — geometry optimization
+- **Annotated examples**: [raw/assets/qe-examples.md](../../raw/assets/qe-examples.md) — SCF, NSCF, bands, relax, MD, phonon
+
+## 参考来源 (Sources)
+
+- `src/qe_lsp/tool.py`: agent CLI and capability manifest loader
+- `raw/assets/DIAGNOSTIC_ENGINE_V1.md`: diagnostic contract
+- [LSP Server Architecture](../concepts/lsp-server-architecture.md): server design


### PR DESCRIPTION
Fixes #87

## Summary
- Add `raw/assets/upstream-qe-reference.md` upstream documentation link manifest
- Add `raw/assets/example-carbonyl-relax.in` from official QE test suite (pw_relax)
- Cross-reference upstream manifest, OpenQC agent context, and relax example in `index.md`
- Expand `lsp-capabilities.json` sourceProvenance (1→6 entries) and enrich `wiki/synthesis/openqc-agent-context.md`
- Add `scripts/wiki-lint.sh` for lightweight orphan/broken-link checks
- CI repair: black-format `tool.py` list literal; add `cast()` for mypy `no-any-return` (no-test justification — formatting + type annotation only)

## Test Plan
- [x] `bash scripts/wiki-lint.sh` — 0 broken links

Made with [Cursor](https://cursor.com)