### PR TITLE
feat(preflight): universal generated-input preflight + DiagnosticEnvelope/v1 (#85)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist/
 node_modules/
 .vscode/
 coverage.xml
+
+.worktrees/

--- a/src/qe_lsp/preflight.py
+++ b/src/qe_lsp/preflight.py
@@ -1,0 +1,1292 @@
+"""Universal generated-input preflight capabilities.
+
+This module implements the four fleet-wide preflight capabilities called out in
+``newtontech/qe-lsp#85`` against a *generic artifact-role model*, so the checks
+generalize to any backend in the scientific LSP fleet instead of being wired to
+MatMaster submission policy:
+
+* ``version-aware-keywords``  - explicit runtime/version assumption metadata and
+  keyword-availability validation derived from the builtin keyword set, never
+  guessed.
+* ``cross-artifact-graph``   - resolves the case as a graph of artifacts with
+  stable roles (primary-input, structure, kpoints, pseudopotential, lattice).
+  For Quantum ESPRESSO the structure/kpoints/lattice roles are in-file cards of
+  the primary ``pw.x`` input (``ATOMIC_POSITIONS``/``K_POINTS``/
+  ``CELL_PARAMETERS``), while the pseudopotential role is the one true
+  cross-file artifact (external ``.UPF`` files referenced per species in the
+  ``ATOMIC_SPECIES`` card). The same role set generalizes to the rest of the
+  fleet (VASP/CP2K/ABINIT/...).
+* ``code-actions``           - normalizes repair hints/actions on every
+  diagnostic and exposes a blocking gate the agent CLI can run as
+  ``check --fail-on-blocking``.
+* ``fleet-regression-fixtures`` - ``fleet_manifest`` returns a machine-readable
+  description of the preflight surface (codes, capabilities, fixture
+  expectations) so the parent ``bohrium_skills`` probe/report workflow can
+  consume regression evidence without re-deriving it.
+
+The diagnostics emitted here are plain dictionaries (not the legacy
+``Diagnostic`` dataclass) so they can carry the richer ``DiagnosticEnvelope/v1``
+fields (``source_provenance``, ``domain_tags``, ``facts``, ``artifact_roles``,
+``version_assumption``, ``actions``) directly.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .parser import ParsedInput, parse_qe_input
+
+# --- Artifact-role model ---------------------------------------------------
+
+# Generic roles. These are intentionally software-agnostic: every fleet backend
+# can map its native files/sections onto this same small role set, which is
+# what lets the parent router consume cross-file checks without learning
+# MatMaster specifics. For QE the primary ``pw.x`` input file holds the in-file
+# structure/kpoints/lattice cards; only pseudopotentials are real external
+# artifacts (the third column of ``ATOMIC_SPECIES``). The graph records both
+# kinds uniformly.
+ROLE_PRIMARY_INPUT = "primary-input"
+ROLE_STRUCTURE = "structure"
+ROLE_KPOINTS = "kpoints"
+ROLE_PSEUDOPOTENTIAL = "pseudopotential"
+ROLE_ORBITAL = "orbital"
+ROLE_LATTICE = "lattice"
+
+ALL_ROLES = (
+    ROLE_PRIMARY_INPUT,
+    ROLE_STRUCTURE,
+    ROLE_KPOINTS,
+    ROLE_PSEUDOPOTENTIAL,
+    ROLE_ORBITAL,
+    ROLE_LATTICE,
+)
+
+# Conservative workflow threshold used by the warning-level ecutwfc check. QE
+# documents ecutwfc in Rydberg. The actual cutoff is overridable via the
+# preflight intent contract; this is only the default fleet baseline, not a
+# MatMaster policy.
+DEFAULT_ECUTWFC_WARNING_RY = 50.0
+
+# Codes reserved for the universal preflight surface. They use the ``QE6xx``
+# band so they sort after existing rule codes (QE0xx/1xx) and stay identifiable
+# as cross-fleet preflight findings.
+CODE_MISSING_INPUT = "QE601"
+CODE_MISSING_STRUCTURE = "QE602"
+CODE_MISSING_LATTICE = "QE603"
+CODE_NTYP_SPECIES_MISMATCH = "QE604"
+CODE_UNRESOLVED_PSEUDO = "QE605"
+CODE_MISSING_PSEUDOS = "QE606"
+CODE_LOW_ECUTWFC = "QE607"
+CODE_SUSPICIOUS_KPOINTS = "QE608"
+CODE_VERSION_ASSUMPTION = "QE609"
+CODE_UNKNOWN_KEYWORD_VERSION = "QE610"
+
+
+@dataclass(frozen=True)
+class ArtifactNode:
+    """A node in the cross-artifact graph.
+
+    ``role`` is one of the fleet-generic roles above; ``path`` is the resolved
+    filesystem path (may be a non-existent reference, which is itself a
+    finding) or, for in-file QE cards, the primary input path; ``exists``
+    records whether the artifact is present; ``source`` records where the
+    reference originated so consumers can trace provenance.
+    """
+
+    role: str
+    path: Path
+    exists: bool
+    source: str
+    referenced_from: tuple[str, int] | None = None
+    detail: dict[str, Any] | None = None
+
+
+@dataclass
+class ArtifactGraph:
+    """Generic cross-artifact graph built from a parsed case directory."""
+
+    case_dir: Path
+    nodes: list[ArtifactNode] = field(default_factory=list)
+
+    def by_role(self, role: str) -> list[ArtifactNode]:
+        return [node for node in self.nodes if node.role == role]
+
+    def to_json(self) -> list[dict[str, Any]]:
+        """Serialize the graph for the parent probe/report workflow."""
+
+        def _node_json(node: ArtifactNode) -> dict[str, Any]:
+            payload: dict[str, Any] = {
+                "role": node.role,
+                "path": str(node.path),
+                "exists": node.exists,
+                "source": node.source,
+            }
+            if node.referenced_from is not None:
+                payload["referenced_from"] = {
+                    "path": node.referenced_from[0],
+                    "line": node.referenced_from[1],
+                }
+            if node.detail:
+                payload["detail"] = node.detail
+            return payload
+
+        return sorted(
+            (_node_json(node) for node in self.nodes),
+            key=lambda item: (item["role"], item["path"]),
+        )
+
+
+def _find_primary_input(case_dir: Path) -> Path | None:
+    """Locate the primary Quantum ESPRESSO input file in a case directory.
+
+    QE pw.x conventionally reads its input from ``.pwi``/``.in`` files (or a
+    file named ``pw.in``/``qe.in``). We pick the first match so the graph has a
+    stable primary node; if none of those exist we fall back to the most
+    generic ``*.in`` so ad-hoc naming still works.
+    """
+    for pattern in ("*.pwi", "*.pw", "pw.in", "qe.in", "pw.x.in", "*.in"):
+        for candidate in sorted(case_dir.glob(pattern)):
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+def _system_param(parsed: ParsedInput, name: str) -> tuple[str, int] | None:
+    """Return (value, line) for a ``&SYSTEM`` keyword, or None when absent."""
+    system = parsed.namelists.get("&SYSTEM", {})
+    entry = system.get(name)
+    if entry is None:
+        return None
+    return entry.value, entry.line + 1
+
+
+def _control_param(parsed: ParsedInput, name: str) -> tuple[str, int] | None:
+    control = parsed.namelists.get("&CONTROL", {})
+    entry = control.get(name)
+    if entry is None:
+        return None
+    return entry.value, entry.line + 1
+
+
+def _has_system_param(parsed: ParsedInput, name: str) -> bool:
+    return name in parsed.namelists.get("&SYSTEM", {})
+
+
+def _card_line(parsed: ParsedInput, card: str) -> int:
+    rows = parsed.cards.get(card, [])
+    return (rows[0].line + 1) if rows else 1
+
+
+def _atomic_species_files(parsed: ParsedInput) -> list[tuple[str, str, int]]:
+    """Return ``[(symbol, pseudo_filename, line), ...]`` from ATOMIC_SPECIES.
+
+    Each ATOMIC_SPECIES row is ``<symbol> <mass> <pseudo_file>``; the third
+    column is the cross-file pseudopotential reference.
+    """
+    out: list[tuple[str, str, int]] = []
+    for row in parsed.cards.get("ATOMIC_SPECIES", []):
+        values = row.values
+        if not values:
+            continue
+        symbol = row.symbol
+        # Mass may be omitted in some malformed inputs; the pseudo filename is
+        # conventionally the last column.
+        if len(values) >= 2:
+            pseudo = values[-1]
+            out.append((symbol, pseudo, row.line + 1))
+        elif len(values) == 1:
+            # Only mass, no pseudo file declared.
+            out.append((symbol, "", row.line + 1))
+    return out
+
+
+def _resolve_dir(case_dir: Path, declared: str | None) -> Path:
+    if not declared:
+        return case_dir
+    candidate = Path(declared)
+    if candidate.is_absolute():
+        return candidate
+    return case_dir / candidate
+
+
+def build_artifact_graph(
+    case_dir: Path,
+    parsed: ParsedInput,
+    input_path: Path,
+) -> ArtifactGraph:
+    """Build the cross-artifact graph from a parsed QE pw.x input.
+
+    The model is generic: it records roles + resolved paths + provenance. The
+    same shape generalizes to other fleet backends because it never bakes in
+    MatMaster/Bohrium runtime concepts (no input_dir, no image, no session).
+    """
+    case_dir = case_dir.resolve()
+    graph = ArtifactGraph(case_dir=case_dir)
+
+    graph.nodes.append(
+        ArtifactNode(
+            role=ROLE_PRIMARY_INPUT,
+            path=input_path,
+            exists=input_path.exists(),
+            source="case-root",
+        )
+    )
+
+    # In-file structure card (ATOMIC_POSITIONS) + the &SYSTEM structural keys.
+    has_positions = bool(parsed.cards.get("ATOMIC_POSITIONS"))
+    has_system_struct = any(_has_system_param(parsed, key) for key in ("nat", "ntyp"))
+    structure_exists = has_positions or has_system_struct
+    structure_line = _card_line(parsed, "ATOMIC_POSITIONS") if has_positions else 1
+    graph.nodes.append(
+        ArtifactNode(
+            role=ROLE_STRUCTURE,
+            path=input_path,
+            exists=structure_exists,
+            source="pwi:ATOMIC_POSITIONS/&SYSTEM",
+            referenced_from=(str(input_path), structure_line),
+            detail={
+                "has_atomic_positions": has_positions,
+                "has_system_struct": has_system_struct,
+            },
+        )
+    )
+
+    # In-file kpoints card.
+    has_kpoints = bool(parsed.cards.get("K_POINTS"))
+    kpt_line = _card_line(parsed, "K_POINTS")
+    graph.nodes.append(
+        ArtifactNode(
+            role=ROLE_KPOINTS,
+            path=input_path,
+            exists=has_kpoints,
+            source="pwi:K_POINTS",
+            referenced_from=(str(input_path), kpt_line),
+            detail={"has_k_points": has_kpoints},
+        )
+    )
+
+    # In-file lattice: CELL_PARAMETERS when ibrav=0, or ibrav>0 + celldm/a.
+    ibrav_entry = _system_param(parsed, "ibrav")
+    ibrav_value: int | None = None
+    if ibrav_entry is not None:
+        try:
+            ibrav_value = int(float(re.split(r"[\s,]", ibrav_entry[0])[0]))
+        except (ValueError, IndexError):
+            ibrav_value = None
+    has_cell_parameters = bool(parsed.cards.get("CELL_PARAMETERS"))
+    has_bravais_lattice = ibrav_value is not None and ibrav_value > 0
+    lattice_exists = has_cell_parameters or has_bravais_lattice
+    lattice_line = _card_line(parsed, "CELL_PARAMETERS") if has_cell_parameters else 1
+    graph.nodes.append(
+        ArtifactNode(
+            role=ROLE_LATTICE,
+            path=input_path,
+            exists=lattice_exists,
+            source="pwi:CELL_PARAMETERS/ibrav",
+            referenced_from=(str(input_path), lattice_line),
+            detail={
+                "ibrav": ibrav_value,
+                "has_cell_parameters": has_cell_parameters,
+            },
+        )
+    )
+
+    # Pseudopotential references (the only true cross-file artifact for QE).
+    pseudo_dir_value = _control_param(parsed, "pseudo_dir")
+    pseudo_dir_str = pseudo_dir_value[0].strip("'\"") if pseudo_dir_value else None
+    for symbol, filename, line in _atomic_species_files(parsed):
+        if not filename:
+            continue
+        resolved = _resolve_dir(case_dir, pseudo_dir_str) / filename
+        graph.nodes.append(
+            ArtifactNode(
+                role=ROLE_PSEUDOPOTENTIAL,
+                path=resolved,
+                exists=resolved.exists(),
+                source=f"pwi:ATOMIC_SPECIES:{symbol}",
+                referenced_from=(str(input_path), line),
+                detail=(
+                    {"declared_dir": pseudo_dir_str, "symbol": symbol}
+                    if pseudo_dir_str
+                    else {"symbol": symbol}
+                ),
+            )
+        )
+
+    return graph
+
+
+# --- Preflight diagnostics -------------------------------------------------
+
+
+def preflight_diagnostics(
+    case_dir: Path,
+    *,
+    intent: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], ArtifactGraph]:
+    """Run universal generated-input preflight checks.
+
+    Returns a tuple of (diagnostics, artifact_graph). Diagnostics are envelope
+    dicts carrying the full ``DiagnosticEnvelope/v1`` field set so the agent
+    CLI can emit them directly without re-shaping.
+    """
+    case_dir = case_dir.resolve()
+    input_path = _find_primary_input(case_dir)
+    if input_path is None:
+        # No primary input at all: emit a single blocking finding and return
+        # an empty graph. The legacy single-file lint path still flags
+        # unsupported files; this finding is the preflight-specific view.
+        empty_graph = ArtifactGraph(case_dir=case_dir)
+        finding = _diag(
+            code=CODE_MISSING_INPUT,
+            severity="error",
+            message=(
+                "primary-input artifact not found: expected a .pwi/.in pw.x "
+                "input file in the case directory"
+            ),
+            path=case_dir / "<missing-input>",
+            line=1,
+            category="cross-file reference",
+            confidence=0.97,
+            blocking=True,
+            source_provenance={
+                "role": ROLE_PRIMARY_INPUT,
+                "reason": "no .pwi/.in file in case directory",
+            },
+            fix_hints=[
+                "Add a pw.x input file (.pwi/.in) to the case directory",
+            ],
+            actions=[
+                {
+                    "kind": "create_artifact",
+                    "role": ROLE_PRIMARY_INPUT,
+                    "target": str(case_dir / "pw.in"),
+                    "safe_to_auto_apply": False,
+                }
+            ],
+            facts={"case_dir": str(case_dir)},
+            artifact_roles=[ROLE_PRIMARY_INPUT],
+            domain_tags=["cross-file", "blocking"],
+        )
+        return [finding], empty_graph
+
+    text = input_path.read_text(encoding="utf-8", errors="ignore")
+    parsed = parse_qe_input(text)
+    graph = build_artifact_graph(case_dir, parsed, input_path)
+
+    version_assumption = resolve_version_assumption(intent)
+    diagnostics: list[dict[str, Any]] = []
+    diagnostics.extend(_structure_diagnostics(graph, parsed, input_path))
+    diagnostics.extend(_lattice_diagnostics(graph, parsed, input_path))
+    diagnostics.extend(_kpoints_presence_diagnostics(graph, parsed, input_path))
+    diagnostics.extend(_ntyp_species_diagnostics(parsed, input_path))
+    diagnostics.extend(_pseudos_diagnostics(graph, parsed, input_path))
+    diagnostics.extend(_unresolved_pseudo_diagnostics(graph))
+    diagnostics.extend(_low_ecutwfc_diagnostics(parsed, input_path, intent))
+    diagnostics.extend(_suspicious_kpoints_diagnostics(parsed, input_path))
+    diagnostics.extend(_version_keyword_diagnostics(parsed, input_path, version_assumption))
+    diagnostics.extend(_version_assumption_diagnostic(version_assumption, intent, input_path))
+
+    return (
+        sorted(
+            diagnostics,
+            key=lambda item: (
+                item.get("range", {}).get("start", {}).get("line", 0),
+                item.get("range", {}).get("start", {}).get("character", 0),
+                item["code"],
+            ),
+        ),
+        graph,
+    )
+
+
+def _diag(
+    *,
+    code: str,
+    severity: str,
+    message: str,
+    path: Path,
+    line: int = 1,
+    column: int = 1,
+    category: str,
+    confidence: float,
+    blocking: bool,
+    source_provenance: dict[str, Any],
+    fix_hints: list[str],
+    actions: list[dict[str, Any]] | None = None,
+    facts: dict[str, Any] | None = None,
+    artifact_roles: list[str] | None = None,
+    domain_tags: list[str] | None = None,
+    version_assumption: dict[str, Any] | None = None,
+    manual_ref: str | None = None,
+    intent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a single normalized preflight diagnostic.
+
+    Carries every field the issue acceptance criteria require (``code``,
+    ``severity``, ``path``/``range``, ``blocking``, ``category``,
+    ``source_provenance``, ``fix_hints``/``actions``) plus the richer envelope
+    fields (``facts``, ``artifact_roles``, ``domain_tags``,
+    ``version_assumption``) used by the parent fleet probe.
+    """
+    line0 = max(line - 1, 0)
+    col0 = max(column - 1, 0)
+    payload: dict[str, Any] = {
+        "code": code,
+        "severity": severity,
+        "message": message,
+        "file": str(path),
+        "line": line,
+        "column": column,
+        "category": category,
+        "confidence": confidence,
+        "source": "qe-preflight",
+        "range": {
+            "start": {"line": line0, "character": col0},
+            "end": {"line": line0, "character": col0 + 1},
+        },
+        "blocking": blocking,
+        "fix_hints": fix_hints,
+        "source_provenance": source_provenance,
+    }
+    if actions:
+        payload["actions"] = actions
+    if facts:
+        payload["facts"] = facts
+    if artifact_roles:
+        payload["artifact_roles"] = artifact_roles
+    if domain_tags:
+        payload["domain_tags"] = domain_tags
+    if version_assumption:
+        payload["version_assumption"] = version_assumption
+    if manual_ref:
+        payload["manual_ref"] = manual_ref
+    if intent:
+        payload["intent"] = intent
+    return payload
+
+
+def _structure_diagnostics(
+    graph: ArtifactGraph, parsed: ParsedInput, input_path: Path
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for node in graph.by_role(ROLE_STRUCTURE):
+        if node.exists:
+            continue
+        ref = node.referenced_from or (str(input_path), 1)
+        out.append(
+            _diag(
+                code=CODE_MISSING_STRUCTURE,
+                severity="error",
+                message=(
+                    "structure section missing: pw.x input declares no "
+                    "ATOMIC_POSITIONS card (and no nat/ntyp in &SYSTEM)"
+                ),
+                path=node.path,
+                line=ref[1],
+                category="cross-file reference",
+                confidence=0.95,
+                blocking=True,
+                source_provenance={
+                    "role": ROLE_STRUCTURE,
+                    "referenced_from": {"path": ref[0], "line": ref[1]},
+                    "declared_in": node.source,
+                },
+                fix_hints=[
+                    "Add an ATOMIC_POSITIONS card listing the atom coordinates",
+                    "And set nat/ntyp in &SYSTEM to match the structure",
+                ],
+                actions=[
+                    {
+                        "kind": "insert_card",
+                        "card": "ATOMIC_POSITIONS",
+                        "target": str(node.path),
+                        "safe_to_auto_apply": False,
+                    }
+                ],
+                facts={
+                    "has_atomic_positions": (node.detail or {}).get("has_atomic_positions", False),
+                    "has_system_struct": (node.detail or {}).get("has_system_struct", False),
+                },
+                artifact_roles=[ROLE_STRUCTURE, ROLE_PRIMARY_INPUT],
+                domain_tags=["cross-file", "blocking"],
+            )
+        )
+    return out
+
+
+def _lattice_diagnostics(
+    graph: ArtifactGraph, parsed: ParsedInput, input_path: Path
+) -> list[dict[str, Any]]:
+    """Flag a missing lattice when ibrav=0 has no CELL_PARAMETERS card.
+
+    QE requires explicit cell vectors when ``ibrav=0``; without them pw.x fails
+    at startup. We surface this as a blocking cross-artifact finding.
+    """
+    out: list[dict[str, Any]] = []
+    ibrav_entry = _system_param(parsed, "ibrav")
+    ibrav_value: int | None = None
+    if ibrav_entry is not None:
+        try:
+            ibrav_value = int(float(re.split(r"[\s,]", ibrav_entry[0])[0]))
+        except (ValueError, IndexError):
+            ibrav_value = None
+    has_cell_parameters = bool(parsed.cards.get("CELL_PARAMETERS"))
+    # Only block when ibrav is explicitly 0 (free cell) and no vectors given.
+    # When ibrav is unset QE defaults to 0, so we still flag a missing lattice
+    # unless a CELL_PARAMETERS card is present.
+    free_cell = ibrav_value == 0 or (ibrav_value is None and not has_cell_parameters)
+    if free_cell and not has_cell_parameters:
+        line = ibrav_entry[1] if ibrav_entry is not None else 1
+        out.append(
+            _diag(
+                code=CODE_MISSING_LATTICE,
+                severity="error",
+                message=(
+                    "lattice section missing: ibrav=0 (or unset) requires a "
+                    "CELL_PARAMETERS card with explicit cell vectors"
+                ),
+                path=input_path,
+                line=line,
+                category="cross-file reference",
+                confidence=0.95,
+                blocking=True,
+                source_provenance={
+                    "role": ROLE_LATTICE,
+                    "referenced_from": {"path": str(input_path), "line": line},
+                    "ibrav": ibrav_value,
+                },
+                fix_hints=[
+                    "Add a CELL_PARAMETERS card with three cell vectors",
+                    "Or set ibrav>0 in &SYSTEM and the matching celldm/a",
+                ],
+                actions=[
+                    {
+                        "kind": "insert_card",
+                        "card": "CELL_PARAMETERS",
+                        "target": str(input_path),
+                        "safe_to_auto_apply": False,
+                    }
+                ],
+                facts={"ibrav": ibrav_value, "has_cell_parameters": has_cell_parameters},
+                artifact_roles=[ROLE_LATTICE, ROLE_PRIMARY_INPUT],
+                domain_tags=["cross-file", "blocking"],
+            )
+        )
+    return out
+
+
+def _kpoints_presence_diagnostics(
+    graph: ArtifactGraph, parsed: ParsedInput, input_path: Path
+) -> list[dict[str, Any]]:
+    """Flag a missing K_POINTS card as a non-blocking warning.
+
+    pw.x requires a K_POINTS card for scf/nscf/bands/relax; its absence is a
+    startup error in practice, but some inputs are intentionally built up
+    incrementally, so we surface this as a non-blocking warning rather than a
+    hard block.
+    """
+    out: list[dict[str, Any]] = []
+    for node in graph.by_role(ROLE_KPOINTS):
+        if node.exists:
+            continue
+        ref = node.referenced_from or (str(input_path), 1)
+        out.append(
+            _diag(
+                code=CODE_SUSPICIOUS_KPOINTS,
+                severity="warning",
+                message=(
+                    "K_POINTS card missing: pw.x requires a K_POINTS card; "
+                    "its absence is a startup error for scf/nscf/bands/relax"
+                ),
+                path=node.path,
+                line=ref[1],
+                category="preflight/runtime-risk",
+                confidence=0.8,
+                blocking=False,
+                source_provenance={
+                    "role": ROLE_KPOINTS,
+                    "referenced_from": {"path": ref[0], "line": ref[1]},
+                    "declared_in": node.source,
+                },
+                fix_hints=[
+                    "Add a K_POINTS card (e.g. automatic with a grid)",
+                    "Or confirm the input is intentionally incomplete",
+                ],
+                actions=[
+                    {
+                        "kind": "insert_card",
+                        "card": "K_POINTS",
+                        "target": str(node.path),
+                        "safe_to_auto_apply": False,
+                    }
+                ],
+                facts={"has_k_points": False},
+                artifact_roles=[ROLE_KPOINTS, ROLE_PRIMARY_INPUT],
+                domain_tags=["preflight", "runtime-risk"],
+            )
+        )
+    return out
+
+
+def _ntyp_species_diagnostics(parsed: ParsedInput, input_path: Path) -> list[dict[str, Any]]:
+    """Cross-check &SYSTEM ntyp against the ATOMIC_SPECIES row count.
+
+    This is the generic "declared count vs evidence count" cross-artifact
+    check; for QE the species list is the ATOMIC_SPECIES card.
+    """
+    out: list[dict[str, Any]] = []
+    ntyp_entry = _system_param(parsed, "ntyp")
+    species_rows = _atomic_species_files(parsed)
+    species_count = len(species_rows)
+    if ntyp_entry is None:
+        # ntyp unset: QE can sometimes infer it, but we surface the assumption
+        # so the parent probe knows it was made.
+        if species_count:
+            out.append(
+                _diag(
+                    code=CODE_NTYP_SPECIES_MISMATCH,
+                    severity="information",
+                    message=("ntyp is unset; pw.x will infer it from the " "ATOMIC_SPECIES card"),
+                    path=input_path,
+                    line=1,
+                    category="semantic consistency",
+                    confidence=0.8,
+                    blocking=False,
+                    source_provenance={
+                        "role": ROLE_PRIMARY_INPUT,
+                        "reason": "ntyp keyword absent from &SYSTEM",
+                    },
+                    fix_hints=[f"Set ntyp={species_count} to make the assumption explicit"],
+                    actions=[
+                        {
+                            "kind": "set_keyword",
+                            "namelist": "&SYSTEM",
+                            "keyword": "ntyp",
+                            "value": str(species_count),
+                            "target": str(input_path),
+                            "safe_to_auto_apply": False,
+                        }
+                    ],
+                    facts={"inferred_ntyp": species_count},
+                    artifact_roles=[ROLE_PRIMARY_INPUT, ROLE_STRUCTURE],
+                    domain_tags=["cross-file", "assumption"],
+                )
+            )
+        return out
+    try:
+        declared = int(float(re.split(r"[\s,]", ntyp_entry[0])[0]))
+    except (ValueError, IndexError):
+        return []
+    if declared != species_count:
+        line = ntyp_entry[1]
+        species_symbols = [row[0] for row in species_rows]
+        out.append(
+            _diag(
+                code=CODE_NTYP_SPECIES_MISMATCH,
+                severity="error",
+                message=(
+                    f"ntyp={declared} does not match the {species_count} "
+                    "species declared in the ATOMIC_SPECIES card"
+                ),
+                path=input_path,
+                line=line,
+                category="semantic consistency",
+                confidence=0.96,
+                blocking=True,
+                source_provenance={
+                    "role": ROLE_PRIMARY_INPUT,
+                    "cross_referenced_role": ROLE_STRUCTURE,
+                    "parsed_ntyp": declared,
+                    "parsed_species": species_symbols,
+                },
+                fix_hints=[
+                    f"Set ntyp={species_count} to match ATOMIC_SPECIES",
+                    "Or correct the ATOMIC_SPECIES card to match ntyp",
+                ],
+                actions=[
+                    {
+                        "kind": "set_keyword",
+                        "namelist": "&SYSTEM",
+                        "keyword": "ntyp",
+                        "value": str(species_count),
+                        "target": str(input_path),
+                        "safe_to_auto_apply": False,
+                    }
+                ],
+                facts={
+                    "declared_ntyp": declared,
+                    "species_count": species_count,
+                    "species": species_symbols,
+                },
+                artifact_roles=[ROLE_PRIMARY_INPUT, ROLE_STRUCTURE],
+                domain_tags=["cross-file", "blocking"],
+            )
+        )
+    return out
+
+
+def _pseudos_diagnostics(
+    graph: ArtifactGraph, parsed: ParsedInput, input_path: Path
+) -> list[dict[str, Any]]:
+    """Flag inputs that declare a structure but no pseudopotential references.
+
+    QE reads pseudopotential filenames from the third column of the
+    ``ATOMIC_SPECIES`` card (and optionally their directory from the
+    ``pseudo_dir`` control keyword). A structure-declaring input without any
+    pseudopotential reference will fail at runtime, so we surface it as a
+    blocking cross-artifact finding.
+    """
+    out: list[dict[str, Any]] = []
+    has_positions = bool(parsed.cards.get("ATOMIC_POSITIONS"))
+    species_rows = _atomic_species_files(parsed)
+    has_pseudo_refs = any(filename for _, filename, _ in species_rows)
+    if (has_positions or species_rows) and not has_pseudo_refs:
+        line = species_rows[0][2] if species_rows else 1
+        out.append(
+            _diag(
+                code=CODE_MISSING_PSEUDOS,
+                severity="error",
+                message=(
+                    "pseudopotential artifact missing: structure is declared "
+                    "but the ATOMIC_SPECIES card lists no pseudopotential files"
+                ),
+                path=input_path,
+                line=line,
+                category="cross-file reference",
+                confidence=0.9,
+                blocking=True,
+                source_provenance={
+                    "role": ROLE_PSEUDOPOTENTIAL,
+                    "reason": "no pseudopotential filename in any ATOMIC_SPECIES row",
+                },
+                fix_hints=[
+                    "Add the pseudopotential filename as the third column of "
+                    "each ATOMIC_SPECIES row",
+                ],
+                actions=[
+                    {
+                        "kind": "set_keyword",
+                        "card": "ATOMIC_SPECIES",
+                        "target": str(input_path),
+                        "safe_to_auto_apply": False,
+                    }
+                ],
+                facts={"has_atomic_positions": has_positions, "species_rows": len(species_rows)},
+                artifact_roles=[ROLE_PSEUDOPOTENTIAL, ROLE_PRIMARY_INPUT],
+                domain_tags=["cross-file", "blocking"],
+            )
+        )
+    return out
+
+
+def _unresolved_pseudo_diagnostics(graph: ArtifactGraph) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for node in graph.by_role(ROLE_PSEUDOPOTENTIAL):
+        if node.exists:
+            continue
+        ref = node.referenced_from or (str(node.path), 1)
+        out.append(
+            _diag(
+                code=CODE_UNRESOLVED_PSEUDO,
+                severity="warning",
+                message=(
+                    f"pseudopotential artifact referenced from ATOMIC_SPECIES "
+                    f"cannot be resolved: {node.path.name}"
+                ),
+                path=node.path,
+                line=ref[1],
+                category="cross-file reference",
+                confidence=0.85,
+                blocking=False,
+                source_provenance={
+                    "role": ROLE_PSEUDOPOTENTIAL,
+                    "declared_in": node.source,
+                    "declared_dir": (node.detail or {}).get("declared_dir"),
+                    "referenced_from": {"path": ref[0], "line": ref[1]},
+                },
+                fix_hints=[
+                    f"Place {node.path.name} in the declared directory",
+                    "Or correct pseudo_dir in &CONTROL",
+                ],
+                actions=[
+                    {
+                        "kind": "resolve_artifact",
+                        "role": ROLE_PSEUDOPOTENTIAL,
+                        "target": str(node.path),
+                        "safe_to_auto_apply": False,
+                    }
+                ],
+                facts={"unresolved_path": str(node.path)},
+                artifact_roles=[ROLE_PSEUDOPOTENTIAL],
+                domain_tags=["cross-file", "workspace-resolve"],
+            )
+        )
+    return out
+
+
+def _low_ecutwfc_diagnostics(
+    parsed: ParsedInput, input_path: Path, intent: dict[str, Any] | None
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    ecut_entry = _system_param(parsed, "ecutwfc")
+    if ecut_entry is None:
+        return out
+    try:
+        ecut = float(re.split(r"[\s,]", ecut_entry[0])[0])
+    except (ValueError, IndexError):
+        return out
+    threshold = float((intent or {}).get("ecutwfc_warning_ry", DEFAULT_ECUTWFC_WARNING_RY))
+    high_accuracy = bool((intent or {}).get("high_accuracy_production", False))
+    if ecut < threshold:
+        message = (
+            f"ecutwfc={ecut} Ry is below the conservative workflow threshold " f"({threshold} Ry)"
+        )
+        if high_accuracy:
+            message += "; intent marks this as high-accuracy production input"
+        line = ecut_entry[1]
+        out.append(
+            _diag(
+                code=CODE_LOW_ECUTWFC,
+                severity="warning",
+                message=message,
+                path=input_path,
+                line=line,
+                category="preflight/runtime-risk",
+                confidence=0.8,
+                blocking=False,
+                source_provenance={
+                    "role": ROLE_PRIMARY_INPUT,
+                    "keyword": "ecutwfc",
+                    "threshold_source": (
+                        "intent" if "ecutwfc_warning_ry" in (intent or {}) else "default"
+                    ),
+                },
+                fix_hints=[
+                    f"Raise ecutwfc to at least {threshold} Ry",
+                    "Or document the lower cutoff in the intent contract",
+                ],
+                actions=[
+                    {
+                        "kind": "set_keyword",
+                        "namelist": "&SYSTEM",
+                        "keyword": "ecutwfc",
+                        "value": str(threshold),
+                        "target": str(input_path),
+                        "safe_to_auto_apply": False,
+                    }
+                ],
+                facts={
+                    "ecutwfc": ecut,
+                    "threshold": threshold,
+                    "high_accuracy_production": high_accuracy,
+                },
+                artifact_roles=[ROLE_PRIMARY_INPUT],
+                domain_tags=["preflight", "runtime-risk"],
+            )
+        )
+    return out
+
+
+def _suspicious_kpoints_diagnostics(parsed: ParsedInput, input_path: Path) -> list[dict[str, Any]]:
+    """Flag a 1-point axis in an automatic K_POINTS grid.
+
+    The automatic form is ``K_POINTS automatic\nnk1 nk2 nk3 k1 k2 k3``. A grid
+    with a 1-point axis risks silently inaccurate results for low-dimensional
+    systems, so we surface it as a non-blocking warning.
+    """
+    out: list[dict[str, Any]] = []
+    header = (parsed.card_headers.get("K_POINTS") or "").upper()
+    rows = parsed.cards.get("K_POINTS", [])
+    if not rows or not header:
+        return out
+    # Only the automatic form declares an explicit nk1/nk2/nk3 grid.
+    is_automatic = "AUTOMATIC" in header
+    if not is_automatic:
+        return out
+    first = rows[0]
+    # The parser stores the first token of each card row as ``symbol`` and the
+    # remainder as ``values``. For the K_POINTS automatic card the whole line
+    # is the grid + shift (nk1 nk2 nk3 k1 k2 k3), so we recombine them.
+    grid_tokens = [first.symbol, *first.values][:3]
+    if len(grid_tokens) < 3:
+        return out
+    try:
+        grid = [int(float(tok)) for tok in grid_tokens]
+    except ValueError:
+        return out
+    if any(component <= 1 for component in grid):
+        line = first.line + 1
+        out.append(
+            _diag(
+                code=CODE_SUSPICIOUS_KPOINTS,
+                severity="warning",
+                message=(
+                    f"k-point grid {grid} contains a 1-point axis; "
+                    "under-sampling risks silently inaccurate results for "
+                    "low-dimensional systems"
+                ),
+                path=input_path,
+                line=line,
+                category="preflight/runtime-risk",
+                confidence=0.7,
+                blocking=False,
+                source_provenance={
+                    "role": ROLE_KPOINTS,
+                    "grid": grid,
+                    "card": "K_POINTS",
+                },
+                fix_hints=[
+                    "Increase the sparse k-point axis",
+                    "Or confirm the system is genuinely low-dimensional",
+                ],
+                actions=[
+                    {
+                        "kind": "set_keyword",
+                        "card": "K_POINTS",
+                        "value": " ".join(str(max(c, 2)) for c in grid),
+                        "target": str(input_path),
+                        "safe_to_auto_apply": False,
+                    }
+                ],
+                facts={"grid": grid, "card": "K_POINTS"},
+                artifact_roles=[ROLE_KPOINTS],
+                domain_tags=["preflight", "runtime-risk"],
+            )
+        )
+    return out
+
+
+# --- version-aware-keywords ------------------------------------------------
+
+
+def resolve_version_assumption(intent: dict[str, Any] | None) -> dict[str, Any]:
+    """Resolve the explicit runtime/version assumption for this preflight run.
+
+    When the exact runtime/image version is unknown we record that fact
+    explicitly rather than guessing, per the issue's version-assumptions
+    acceptance criterion. The intent contract can override
+    ``software_version`` (e.g. ``qe >=7.2``); otherwise we fall back to the
+    schema version the builtin keyword set was authored against.
+    """
+    intent = intent or {}
+    software_version = intent.get("software_version")
+    runtime_image = intent.get("runtime_image")
+    assumption: dict[str, Any] = {
+        "software": "qe",
+        "software_version": software_version or "unknown",
+        "runtime_image": runtime_image or "unknown",
+        "schema_source": intent.get("schema_source", "qe-lsp builtin"),
+        # The fallback is intentional and explicit so consumers never have to
+        # guess whether ``unknown`` means "not checked" or "could not determine".
+        "exact_runtime_known": bool(software_version or runtime_image),
+    }
+    if software_version or runtime_image:
+        assumption["declared_by"] = "intent"
+    else:
+        assumption["declared_by"] = "fallback"
+    return assumption
+
+
+# Keywords introduced or only valid for recent QE versions, with the minimal
+# version each one requires. This is the version-aware schema that drives
+# CODE_UNKNOWN_KEYWORD_VERSION: when a keyword is used below its introduction
+# version, the parent probe can act on the mismatch. The versions below are
+# conservative public-reference milestones from the QE pw.x manual.
+_VERSIONED_KEYWORDS: dict[str, str] = {
+    # Each value documents the minimal QE version that introduced / stabilized
+    # the keyword, so preflight can flag inputs that rely on it without
+    # declaring a compatible runtime version.
+    "vdw_kernel_table": "qe >=5.0",
+    "london": "qe >=5.0",
+    "ts_vdw": "qe >=5.0",
+    "xdm": "qe >=5.4",
+    "q2_sigma": "qe >=6.0",
+    "space_group": "qe >=6.0",
+    "gate": "qe >=6.4",
+    "tot_charge": "qe >=6.4",
+    "assume_isolated": "qe >=5.1",
+}
+
+
+def _version_keyword_diagnostics(
+    parsed: ParsedInput,
+    input_path: Path,
+    version_assumption: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Flag keywords whose declared availability is newer than the runtime assumption.
+
+    This is the version-aware-keywords capability: when an input uses a keyword
+    that requires a newer QE version than the intent/runtime declares, we
+    surface an explicit version mismatch so the parent probe can fail early
+    rather than discovering the incompatibility at runtime.
+    """
+    out: list[dict[str, Any]] = []
+    declared_version = version_assumption.get("software_version", "unknown")
+    exact_known = version_assumption.get("exact_runtime_known", False)
+    # Aggregate keyword presence across all namelists so we catch a versioned
+    # keyword no matter which namelist it appears in.
+    present: dict[str, tuple[str, int]] = {}
+    for namelist, params in parsed.namelists.items():
+        for name, param in params.items():
+            if name in _VERSIONED_KEYWORDS and name not in present:
+                present[name] = (namelist, param.line + 1)
+    for keyword, required in _VERSIONED_KEYWORDS.items():
+        if keyword not in present:
+            continue
+        # Only emit when the runtime version is declared AND older than the
+        # keyword requirement. When the version is unknown we leave the generic
+        # CODE_VERSION_ASSUMPTION information diagnostic to carry that fact, so
+        # we never guess at an incompatibility we cannot evidence.
+        if not exact_known:
+            continue
+        if not _version_lt(declared_version, required):
+            continue
+        namelist, line = present[keyword]
+        out.append(
+            _diag(
+                code=CODE_UNKNOWN_KEYWORD_VERSION,
+                severity="error",
+                message=(
+                    f"keyword {keyword} requires {required} but the declared "
+                    f"runtime version is {declared_version}"
+                ),
+                path=input_path,
+                line=line,
+                category="schema",
+                confidence=0.9,
+                blocking=True,
+                source_provenance={
+                    "role": ROLE_PRIMARY_INPUT,
+                    "keyword": keyword,
+                    "namelist": namelist,
+                    "schema_source": version_assumption.get("schema_source"),
+                },
+                fix_hints=[
+                    f"Raise the declared runtime version to at least {required}",
+                    f"Or remove {keyword} from {namelist}",
+                ],
+                actions=[
+                    {
+                        "kind": "remove_keyword",
+                        "keyword": keyword,
+                        "namelist": namelist,
+                        "target": str(input_path),
+                        "safe_to_auto_apply": False,
+                    }
+                ],
+                facts={
+                    "keyword": keyword,
+                    "required_version": required,
+                    "declared_version": declared_version,
+                    "namelist": namelist,
+                },
+                artifact_roles=[ROLE_PRIMARY_INPUT],
+                domain_tags=["schema", "version-aware", "blocking"],
+                version_assumption=version_assumption,
+                manual_ref=version_assumption.get("schema_source"),
+            )
+        )
+    return out
+
+
+def _version_lt(declared: str, required: str) -> bool:
+    """Best-effort ``declared < required`` comparison for version strings.
+
+    Both inputs are of the form ``qe >=X.Y``. We extract the leading numeric
+    tuple from each and compare element-wise. Returns False if either side
+    cannot be parsed, so we never fabricate a version mismatch.
+    """
+
+    def _tuple(text: str) -> tuple[int, ...]:
+        match = re.search(r"(\d+(?:\.\d+)*)", text)
+        if not match:
+            return ()
+        return tuple(int(part) for part in match.group(1).split("."))
+
+    d = _tuple(declared)
+    r = _tuple(required)
+    if not d or not r:
+        return False
+    length = max(len(d), len(r))
+    d_padded = d + (0,) * (length - len(d))
+    r_padded = r + (0,) * (length - len(r))
+    return d_padded < r_padded
+
+
+def _version_assumption_diagnostic(
+    version_assumption: dict[str, Any],
+    intent: dict[str, Any] | None,
+    input_path: Path,
+) -> list[dict[str, Any]]:
+    """Emit an explicit information diagnostic when the runtime version is unknown.
+
+    This makes the version assumption machine-readable in the diagnostic stream
+    itself (not just metadata) so the parent probe can surface it without
+    parsing the envelope top-level.
+    """
+    if version_assumption["exact_runtime_known"]:
+        return []
+    return [
+        _diag(
+            code=CODE_VERSION_ASSUMPTION,
+            severity="information",
+            message=(
+                "Exact Quantum ESPRESSO runtime/image version is unknown; "
+                "preflight validated against the builtin schema keyword set"
+            ),
+            path=input_path,
+            line=1,
+            category="preflight/runtime-risk",
+            confidence=1.0,
+            blocking=False,
+            source_provenance={
+                "role": ROLE_PRIMARY_INPUT,
+                "reason": "software_version and runtime_image not declared in intent",
+            },
+            fix_hints=[
+                "Declare software_version/runtime_image in the intent contract",
+            ],
+            actions=[],
+            facts={
+                "software_version": version_assumption["software_version"],
+                "runtime_image": version_assumption["runtime_image"],
+                "schema_source": version_assumption["schema_source"],
+            },
+            artifact_roles=[ROLE_PRIMARY_INPUT],
+            domain_tags=["version-aware", "assumption"],
+            version_assumption=version_assumption,
+            intent=dict(intent) if intent else None,
+        )
+    ]
+
+
+# --- fleet-regression-fixtures --------------------------------------------
+
+
+def fleet_manifest(
+    *,
+    fixtures: Iterable[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Return a machine-readable preflight manifest for the parent fleet.
+
+    The parent ``bohrium_skills`` probe/report workflow consumes this to know
+    which preflight codes exist, which capabilities are implemented, and which
+    fixtures exercise them. Keeping it as data (not README prose) means the
+    fleet regression evidence stays in sync with the implementation.
+    """
+    codes = {
+        CODE_MISSING_INPUT: {
+            "severity": "error",
+            "category": "cross-file reference",
+            "blocking": True,
+            "capability": "cross-artifact-graph",
+            "summary": "primary-input artifact missing from workspace",
+        },
+        CODE_MISSING_STRUCTURE: {
+            "severity": "error",
+            "category": "cross-file reference",
+            "blocking": True,
+            "capability": "cross-artifact-graph",
+            "summary": "ATOMIC_POSITIONS card / &SYSTEM structure keys missing",
+        },
+        CODE_MISSING_LATTICE: {
+            "severity": "error",
+            "category": "cross-file reference",
+            "blocking": True,
+            "capability": "cross-artifact-graph",
+            "summary": "ibrav=0 without a CELL_PARAMETERS card",
+        },
+        CODE_NTYP_SPECIES_MISMATCH: {
+            "severity": "error",
+            "category": "semantic consistency",
+            "blocking": True,
+            "capability": "cross-artifact-graph",
+            "summary": "ntyp does not match the ATOMIC_SPECIES row count",
+        },
+        CODE_MISSING_PSEUDOS: {
+            "severity": "error",
+            "category": "cross-file reference",
+            "blocking": True,
+            "capability": "cross-artifact-graph",
+            "summary": "structure declared but no pseudopotential filenames",
+        },
+        CODE_UNRESOLVED_PSEUDO: {
+            "severity": "warning",
+            "category": "cross-file reference",
+            "blocking": False,
+            "capability": "cross-artifact-graph",
+            "summary": "pseudopotential file cannot be resolved",
+        },
+        CODE_LOW_ECUTWFC: {
+            "severity": "warning",
+            "category": "preflight/runtime-risk",
+            "blocking": False,
+            "capability": "version-aware-keywords",
+            "summary": "ecutwfc below conservative workflow threshold",
+        },
+        CODE_SUSPICIOUS_KPOINTS: {
+            "severity": "warning",
+            "category": "preflight/runtime-risk",
+            "blocking": False,
+            "capability": "cross-artifact-graph",
+            "summary": "k-point grid has a 1-point axis or is undeclared",
+        },
+        CODE_VERSION_ASSUMPTION: {
+            "severity": "information",
+            "category": "preflight/runtime-risk",
+            "blocking": False,
+            "capability": "version-aware-keywords",
+            "summary": "exact runtime version unknown; fallback schema used",
+        },
+        CODE_UNKNOWN_KEYWORD_VERSION: {
+            "severity": "error",
+            "category": "schema",
+            "blocking": True,
+            "capability": "version-aware-keywords",
+            "summary": "keyword requires a newer runtime than declared",
+        },
+    }
+    capabilities = {
+        "version-aware-keywords": {
+            "status": "available",
+            "evidence_codes": [
+                CODE_UNKNOWN_KEYWORD_VERSION,
+                CODE_VERSION_ASSUMPTION,
+                CODE_LOW_ECUTWFC,
+            ],
+        },
+        "cross-artifact-graph": {
+            "status": "available",
+            "roles": list(ALL_ROLES),
+            "evidence_codes": [
+                CODE_MISSING_INPUT,
+                CODE_MISSING_STRUCTURE,
+                CODE_MISSING_LATTICE,
+                CODE_NTYP_SPECIES_MISMATCH,
+                CODE_MISSING_PSEUDOS,
+                CODE_UNRESOLVED_PSEUDO,
+                CODE_SUSPICIOUS_KPOINTS,
+            ],
+        },
+        "code-actions": {
+            "status": "available",
+            "blocking_gate": "qe-lsp-tool check --fail-on-blocking",
+            "evidence_codes": list(codes.keys()),
+        },
+        "fleet-regression-fixtures": {
+            "status": "available",
+            "fixtures": list(fixtures) if fixtures else [],
+        },
+    }
+    return {
+        "software": "qe",
+        "preflight_envelope": "DiagnosticEnvelope/v1",
+        "artifact_roles": list(ALL_ROLES),
+        "capabilities": capabilities,
+        "codes": codes,
+    }

--- a/src/qe_lsp/rich_diagnostics.py
+++ b/src/qe_lsp/rich_diagnostics.py
@@ -6,10 +6,18 @@ python-lsp-server-style provider boundary for agent-facing JSON consumers.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import asdict, is_dataclass
-from typing import Any, Iterable
+from typing import Any
 
 DIAGNOSTIC_ENGINE_VERSION = "1.0"
+# Normalized cross-fleet preflight envelope. Parent routers (bohrium_skills)
+# consume this stable shape; backends stay free to populate whatever subset of
+# the optional fields they can evidence. ``diagnostic_engine`` keeps the
+# legacy "1.0" label for existing consumers; ``diagnostic_envelope`` names the
+# stable fleet contract so the parent probe can branch on it without breaking
+# older readers.
+DIAGNOSTIC_ENVELOPE_VERSION = "v1"
 DIAGNOSTIC_CATEGORIES = (
     "syntax",
     "schema",
@@ -58,7 +66,15 @@ def infer_category(code: Any = None, message: str = "", source: str = "") -> str
         return "type/value"
     if any(
         token in text
-        for token in ("file", "path", "include", "basis", "pseudo", "potcar", "reference")
+        for token in (
+            "file",
+            "path",
+            "include",
+            "basis",
+            "pseudo",
+            "potcar",
+            "reference",
+        )
     ):
         return "cross-file reference"
     if any(token in text for token in ("deprecated", "style", "format", "indent")):
@@ -156,8 +172,9 @@ def diagnostic_to_dict(
         suggested_fix = legacy.get("suggested_fix")
         fix_hints = [] if suggested_fix is None else [suggested_fix]
     blocking = bool(legacy.get("blocking", severity == "error" and confidence >= 0.8))
-    return {
+    payload: dict[str, Any] = {
         "diagnostic_engine": DIAGNOSTIC_ENGINE_VERSION,
+        "diagnostic_envelope": DIAGNOSTIC_ENVELOPE_VERSION,
         "code": str(code or "diagnostic"),
         "severity": severity,
         "category": category,
@@ -174,6 +191,31 @@ def diagnostic_to_dict(
         "blocking": blocking,
         "message": str(message or ""),
     }
+    # Optional envelope fields. Carried only when the producer evidences them,
+    # so legacy callers keep a stable shape while preflight diagnostics grow
+    # the richer contract the fleet parent consumes.
+    actions = legacy.get("actions")
+    if actions:
+        payload["actions"] = list(actions)
+    source_provenance = legacy.get("source_provenance")
+    if source_provenance:
+        payload["source_provenance"] = source_provenance
+    domain_tags = legacy.get("domain_tags")
+    if domain_tags:
+        payload["domain_tags"] = list(domain_tags)
+    facts = legacy.get("facts")
+    if facts:
+        payload["facts"] = facts
+    artifact_roles = legacy.get("artifact_roles")
+    if artifact_roles:
+        payload["artifact_roles"] = list(artifact_roles)
+    version_assumption = legacy.get("version_assumption")
+    if version_assumption:
+        payload["version_assumption"] = version_assumption
+    intent = legacy.get("intent")
+    if intent:
+        payload["intent"] = intent
+    return payload
 
 
 def serialize_diagnostics(
@@ -208,6 +250,9 @@ def agent_check_payload(
     diagnostics: Iterable[Any] = (),
     path: str = "",
     file_type: str = "",
+    intent: dict[str, Any] | None = None,
+    version_assumption: dict[str, Any] | None = None,
+    artifacts: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build the stable top-level JSON payload returned by *-lsp-tool."""
     items = serialize_diagnostics(
@@ -217,13 +262,14 @@ def agent_check_payload(
         file_type=file_type,
     )
     blocking_count = sum(1 for item in items if item["blocking"])
-    return {
+    payload: dict[str, Any] = {
         "uri": uri,
         "operation": operation,
         "ok": blocking_count == 0,
         "version": version,
         "software": software,
         "diagnostic_engine": version,
+        "diagnostic_envelope": DIAGNOSTIC_ENVELOPE_VERSION,
         "diagnostics": items,
         "summary": {
             "count": len(items),
@@ -232,3 +278,13 @@ def agent_check_payload(
             "warnings": sum(1 for item in items if item["severity"] == "warning"),
         },
     }
+    # Intent + version assumptions live at the envelope top level so the parent
+    # router can branch on them without re-parsing every diagnostic. They are
+    # optional; callers that cannot evidence them omit them.
+    if intent:
+        payload["intent"] = intent
+    if version_assumption:
+        payload["version_assumption"] = version_assumption
+    if artifacts:
+        payload["artifacts"] = list(artifacts)
+    return payload

--- a/src/qe_lsp/tool.py
+++ b/src/qe_lsp/tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from .agent_operations import operation_path, with_capabilities
 from .rich_diagnostics import agent_check_payload
@@ -17,7 +17,8 @@ def _capabilities_payload() -> dict[str, Any]:
     for parent in Path(__file__).resolve().parents:
         manifest_path = parent / "lsp-capabilities.json"
         if manifest_path.exists():
-            return cast(dict[str, Any], json.loads(manifest_path.read_text(encoding="utf-8")))
+            payload: dict[str, Any] = json.loads(manifest_path.read_text(encoding="utf-8"))
+            return payload
     return {
         "schema": "OpenQCLspCapabilities",
         "version": 1,
@@ -31,11 +32,14 @@ def _capabilities_payload() -> dict[str, Any]:
             "fix-preview",
             "llm-wiki",
             "openqc-context",
+            "preflight",
         ],
         "agentCli": {
             "operations": [
                 "capabilities",
                 "check",
+                "preflight",
+                "manifest",
                 "context",
                 "complete",
                 "hover",
@@ -62,6 +66,11 @@ def _collect_diagnostics(path: Path) -> list[Any]:
     from .features.lint import LintProvider
     from .features.typecheck import TypecheckProvider
 
+    # The legacy single-file providers lint one input at a time. When the
+    # caller passes a case directory (the preflight path), there is no single
+    # file text to lint; preflight provides the cross-file view instead.
+    if path.is_dir():
+        return []
     text = path.read_text(encoding="utf-8")
     diagnostics = list(DiagnosticProvider(None).get_diagnostics(text))  # type: ignore[arg-type]
     diagnostics.extend(LintProvider().lint(text))
@@ -69,17 +78,130 @@ def _collect_diagnostics(path: Path) -> list[Any]:
     return diagnostics
 
 
+def _load_intent(path: Path) -> dict[str, Any] | None:
+    """Load the optional preflight intent contract for a case directory.
+
+    The intent contract is the only place preflight policy overrides live
+    (e.g. ``software_version``, ``ecutwfc_warning_ry``,
+    ``high_accuracy_production``). It is a workspace-local artifact, never a
+    MatMaster/Bohrium runtime concept.
+    """
+    case_dir = path if path.is_dir() else path.parent
+    intent_path = case_dir / ".qe-lsp" / "intent.json"
+    if not intent_path.exists():
+        return None
+    try:
+        data = json.loads(intent_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _looks_like_workspace(case_dir: Path) -> bool:
+    """True when a directory is a real generated-input workspace.
+
+    Preflight needs at least a primary ``pw.x`` input to build a meaningful
+    cross-artifact graph. A directory with no recognized input keeps the legacy
+    single-file lint path so callers that lint one file at a time are
+    unaffected.
+    """
+    if not case_dir.is_dir():
+        return False
+    for pattern in ("*.pwi", "*.pw", "pw.in", "qe.in", "pw.x.in", "*.in"):
+        for _ in case_dir.glob(pattern):
+            return True
+    return False
+
+
+def _collect_preflight(
+    path: Path, intent: dict[str, Any] | None
+) -> tuple[list[Any], list[dict[str, Any]], dict[str, Any]]:
+    """Return (preflight_diagnostics, artifact_graph, version_assumption).
+
+    Imported lazily so callers that never touch preflight (e.g. single-file
+    LSP hover) pay no import cost.
+    """
+    from .preflight import preflight_diagnostics, resolve_version_assumption
+
+    case_dir = path if path.is_dir() else path.parent
+    diagnostics, graph = preflight_diagnostics(case_dir, intent=intent)
+    version_assumption = resolve_version_assumption(intent)
+    return diagnostics, graph.to_json(), version_assumption
+
+
 def check_path(path: Path) -> dict[str, Any]:
     uri = path.resolve().as_uri()
+    intent = _load_intent(path)
     diagnostics = _collect_diagnostics(path)
-    return agent_check_payload(
+    # Universal preflight diagnostics augment the legacy provider output, but
+    # only when the caller passes a *case directory*. A bare single input file
+    # keeps the legacy single-file behavior so existing consumers that lint
+    # one input at a time are unaffected (QE inputs are single files, so there
+    # is no cross-file graph to build for an isolated file path).
+    artifacts: list[dict[str, Any]] = []
+    version_assumption: dict[str, Any] | None = None
+    if path.is_dir() and _looks_like_workspace(path):
+        preflight, artifacts, version_assumption = _collect_preflight(path, intent)
+        diagnostics.extend(preflight)
+    payload = agent_check_payload(
         software=SOFTWARE,
         uri=uri,
         operation="check",
         diagnostics=diagnostics,
         path=str(path),
         file_type=_file_type(path),
+        intent=intent,
+        version_assumption=version_assumption,
+        artifacts=artifacts,
     )
+    return payload
+
+
+def preflight_path(path: Path) -> dict[str, Any]:
+    """Return a preflight-only payload (universal checks, no legacy providers)."""
+    from .preflight import preflight_diagnostics, resolve_version_assumption
+
+    intent = _load_intent(path)
+    case_dir = path if path.is_dir() else path.parent
+    diagnostics, graph = preflight_diagnostics(case_dir, intent=intent)
+    version_assumption = resolve_version_assumption(intent)
+    payload = agent_check_payload(
+        software=SOFTWARE,
+        uri=case_dir.resolve().as_uri(),
+        operation="preflight",
+        diagnostics=diagnostics,
+        path=str(case_dir),
+        file_type="case-dir",
+        intent=intent,
+        version_assumption=version_assumption,
+        artifacts=graph.to_json(),
+    )
+    return with_capabilities(payload, "preflight")
+
+
+def manifest_path(path: Path | None = None) -> dict[str, Any]:
+    """Return the fleet preflight manifest.
+
+    When ``path`` is given, fixture expectations declared in
+    ``.qe-lsp/fixtures.json`` are merged in so the parent probe can confirm a
+    case directory exercises the documented codes.
+    """
+    from .preflight import fleet_manifest
+
+    fixtures: list[dict[str, Any]] = []
+    if path is not None:
+        case_dir = path if path.is_dir() else path.parent
+        fixtures_path = case_dir / ".qe-lsp" / "fixtures.json"
+        if fixtures_path.exists():
+            try:
+                data = json.loads(fixtures_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                data = None
+            if isinstance(data, list):
+                fixtures = [item for item in data if isinstance(item, dict)]
+            elif isinstance(data, dict) and isinstance(data.get("fixtures"), list):
+                fixtures = [item for item in data["fixtures"] if isinstance(item, dict)]
+    return fleet_manifest(fixtures=fixtures)
 
 
 def _operation_payload(
@@ -104,9 +226,26 @@ def main(argv: list[str] | None = None) -> int:
     subparsers = parser.add_subparsers(dest="operation", required=True)
     capabilities = subparsers.add_parser("capabilities")
     capabilities.add_argument("--format", choices=["json"], default="json")
-    for operation in ("check", "context", "complete", "hover", "symbols", "fix"):
+    for operation in (
+        "check",
+        "preflight",
+        "manifest",
+        "context",
+        "complete",
+        "hover",
+        "symbols",
+        "fix",
+    ):
         sub = subparsers.add_parser(operation)
-        sub.add_argument("path", type=Path)
+        if operation == "manifest":
+            sub.add_argument(
+                "path",
+                type=Path,
+                nargs="?",
+                help="Optional case directory to merge fixture expectations from.",
+            )
+        else:
+            sub.add_argument("path", type=Path)
         sub.add_argument("--format", choices=["json"], default="json")
         sub.add_argument(
             "--line",
@@ -120,7 +259,7 @@ def main(argv: list[str] | None = None) -> int:
             default=0,
             help="0-based character for position-aware operations.",
         )
-        if operation == "check":
+        if operation in {"check", "preflight"}:
             sub.add_argument("--fail-on-blocking", action="store_true")
     args = parser.parse_args(argv)
 
@@ -131,6 +270,14 @@ def main(argv: list[str] | None = None) -> int:
         payload = with_capabilities(check_path(args.path), "check")
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 1 if getattr(args, "fail_on_blocking", False) and not payload["ok"] else 0
+    if args.operation == "preflight":
+        payload = preflight_path(args.path)
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 1 if getattr(args, "fail_on_blocking", False) and not payload["ok"] else 0
+    if args.operation == "manifest":
+        payload = manifest_path(getattr(args, "path", None))
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
     payload = _operation_payload(args.path, args.operation, args.line, args.character)
     print(json.dumps(payload, indent=2, sort_keys=True))
     return 0

--- a/tests/fixtures/preflight/keyword_version_mismatch/.qe-lsp/intent.json
+++ b/tests/fixtures/preflight/keyword_version_mismatch/.qe-lsp/intent.json
@@ -1,0 +1,4 @@
+{
+  "software_version": "qe >=5.0",
+  "schema_source": "qe-lsp builtin"
+}

--- a/tests/fixtures/preflight/keyword_version_mismatch/Si.pbe-n-rrkjus_psl.1.0.0.UPF
+++ b/tests/fixtures/preflight/keyword_version_mismatch/Si.pbe-n-rrkjus_psl.1.0.0.UPF
@@ -1,0 +1,4 @@
+<UPF version="2.0.1">
+Stub pseudopotential for the qe-lsp preflight regression fixture.
+<PP_INFO generated="qe-lsp-preflight-fixture" />
+</UPF>

--- a/tests/fixtures/preflight/keyword_version_mismatch/pw.in
+++ b/tests/fixtures/preflight/keyword_version_mismatch/pw.in
@@ -1,0 +1,28 @@
+&CONTROL
+  calculation = 'scf'
+  prefix = 'si'
+  pseudo_dir = './'
+/
+&SYSTEM
+  ibrav = 0
+  nat = 2
+  ntyp = 1
+  ecutwfc = 60.0
+  ecutrho = 480.0
+  gate = .true.
+  tot_charge = 1.0
+/
+&ELECTRONS
+  conv_thr = 1.0d-8
+/
+ATOMIC_SPECIES
+  Si 28.0855 Si.pbe-n-rrkjus_psl.1.0.0.UPF
+ATOMIC_POSITIONS crystal
+  Si 0.00 0.00 0.00
+  Si 0.25 0.25 0.25
+K_POINTS automatic
+  4 4 4 0 0 0
+CELL_PARAMETERS angstrom
+  0.000 2.715 2.715
+  2.715 0.000 2.715
+  2.715 2.715 0.000

--- a/tests/fixtures/preflight/low_ecutwfc/Si.pbe-n-rrkjus_psl.1.0.0.UPF
+++ b/tests/fixtures/preflight/low_ecutwfc/Si.pbe-n-rrkjus_psl.1.0.0.UPF
@@ -1,0 +1,4 @@
+<UPF version="2.0.1">
+Stub pseudopotential for the qe-lsp preflight regression fixture.
+<PP_INFO generated="qe-lsp-preflight-fixture" />
+</UPF>

--- a/tests/fixtures/preflight/low_ecutwfc/pw.in
+++ b/tests/fixtures/preflight/low_ecutwfc/pw.in
@@ -1,0 +1,26 @@
+&CONTROL
+  calculation = 'scf'
+  prefix = 'si'
+  pseudo_dir = './'
+/
+&SYSTEM
+  ibrav = 0
+  nat = 2
+  ntyp = 1
+  ecutwfc = 20.0
+  ecutrho = 160.0
+/
+&ELECTRONS
+  conv_thr = 1.0d-8
+/
+ATOMIC_SPECIES
+  Si 28.0855 Si.pbe-n-rrkjus_psl.1.0.0.UPF
+ATOMIC_POSITIONS crystal
+  Si 0.00 0.00 0.00
+  Si 0.25 0.25 0.25
+K_POINTS automatic
+  4 4 4 0 0 0
+CELL_PARAMETERS angstrom
+  0.000 2.715 2.715
+  2.715 0.000 2.715
+  2.715 2.715 0.000

--- a/tests/fixtures/preflight/missing_cell_parameters/Si.pbe-n-rrkjus_psl.1.0.0.UPF
+++ b/tests/fixtures/preflight/missing_cell_parameters/Si.pbe-n-rrkjus_psl.1.0.0.UPF
@@ -1,0 +1,4 @@
+<UPF version="2.0.1">
+Stub pseudopotential for the qe-lsp preflight regression fixture.
+<PP_INFO generated="qe-lsp-preflight-fixture" />
+</UPF>

--- a/tests/fixtures/preflight/missing_cell_parameters/pw.in
+++ b/tests/fixtures/preflight/missing_cell_parameters/pw.in
@@ -1,0 +1,22 @@
+&CONTROL
+  calculation = 'scf'
+  prefix = 'si'
+  pseudo_dir = './'
+/
+&SYSTEM
+  ibrav = 0
+  nat = 2
+  ntyp = 1
+  ecutwfc = 60.0
+  ecutrho = 480.0
+/
+&ELECTRONS
+  conv_thr = 1.0d-8
+/
+ATOMIC_SPECIES
+  Si 28.0855 Si.pbe-n-rrkjus_psl.1.0.0.UPF
+ATOMIC_POSITIONS crystal
+  Si 0.00 0.00 0.00
+  Si 0.25 0.25 0.25
+K_POINTS automatic
+  4 4 4 0 0 0

--- a/tests/fixtures/preflight/missing_kpoints/Si.pbe-n-rrkjus_psl.1.0.0.UPF
+++ b/tests/fixtures/preflight/missing_kpoints/Si.pbe-n-rrkjus_psl.1.0.0.UPF
@@ -1,0 +1,4 @@
+<UPF version="2.0.1">
+Stub pseudopotential for the qe-lsp preflight regression fixture.
+<PP_INFO generated="qe-lsp-preflight-fixture" />
+</UPF>

--- a/tests/fixtures/preflight/missing_kpoints/pw.in
+++ b/tests/fixtures/preflight/missing_kpoints/pw.in
@@ -1,0 +1,24 @@
+&CONTROL
+  calculation = 'scf'
+  prefix = 'si'
+  pseudo_dir = './'
+/
+&SYSTEM
+  ibrav = 0
+  nat = 2
+  ntyp = 1
+  ecutwfc = 60.0
+  ecutrho = 480.0
+/
+&ELECTRONS
+  conv_thr = 1.0d-8
+/
+ATOMIC_SPECIES
+  Si 28.0855 Si.pbe-n-rrkjus_psl.1.0.0.UPF
+ATOMIC_POSITIONS crystal
+  Si 0.00 0.00 0.00
+  Si 0.25 0.25 0.25
+CELL_PARAMETERS angstrom
+  0.000 2.715 2.715
+  2.715 0.000 2.715
+  2.715 2.715 0.000

--- a/tests/fixtures/preflight/missing_pseudos/pw.in
+++ b/tests/fixtures/preflight/missing_pseudos/pw.in
@@ -1,0 +1,26 @@
+&CONTROL
+  calculation = 'scf'
+  prefix = 'si'
+  pseudo_dir = './'
+/
+&SYSTEM
+  ibrav = 0
+  nat = 2
+  ntyp = 1
+  ecutwfc = 60.0
+  ecutrho = 480.0
+/
+&ELECTRONS
+  conv_thr = 1.0d-8
+/
+ATOMIC_SPECIES
+  Si 28.0855
+ATOMIC_POSITIONS crystal
+  Si 0.00 0.00 0.00
+  Si 0.25 0.25 0.25
+K_POINTS automatic
+  4 4 4 0 0 0
+CELL_PARAMETERS angstrom
+  0.000 2.715 2.715
+  2.715 0.000 2.715
+  2.715 2.715 0.000

--- a/tests/fixtures/preflight/ntyp_mismatch/O.pbe-n-kjpaw_psl.0.1.UPF
+++ b/tests/fixtures/preflight/ntyp_mismatch/O.pbe-n-kjpaw_psl.0.1.UPF
@@ -1,0 +1,4 @@
+<UPF version="2.0.1">
+Stub pseudopotential for the qe-lsp preflight regression fixture.
+<PP_INFO generated="qe-lsp-preflight-fixture" />
+</UPF>

--- a/tests/fixtures/preflight/ntyp_mismatch/Si.pbe-n-rrkjus_psl.1.0.0.UPF
+++ b/tests/fixtures/preflight/ntyp_mismatch/Si.pbe-n-rrkjus_psl.1.0.0.UPF
@@ -1,0 +1,4 @@
+<UPF version="2.0.1">
+Stub pseudopotential for the qe-lsp preflight regression fixture.
+<PP_INFO generated="qe-lsp-preflight-fixture" />
+</UPF>

--- a/tests/fixtures/preflight/ntyp_mismatch/pw.in
+++ b/tests/fixtures/preflight/ntyp_mismatch/pw.in
@@ -1,0 +1,27 @@
+&CONTROL
+  calculation = 'scf'
+  prefix = 'sio'
+  pseudo_dir = './'
+/
+&SYSTEM
+  ibrav = 0
+  nat = 2
+  ntyp = 1
+  ecutwfc = 60.0
+  ecutrho = 480.0
+/
+&ELECTRONS
+  conv_thr = 1.0d-8
+/
+ATOMIC_SPECIES
+  Si 28.0855 Si.pbe-n-rrkjus_psl.1.0.0.UPF
+  O  15.9994 O.pbe-n-kjpaw_psl.0.1.UPF
+ATOMIC_POSITIONS crystal
+  Si 0.00 0.00 0.00
+  O  0.50 0.50 0.50
+K_POINTS automatic
+  4 4 4 0 0 0
+CELL_PARAMETERS angstrom
+  0.000 2.715 2.715
+  2.715 0.000 2.715
+  2.715 2.715 0.000

--- a/tests/fixtures/preflight/suspicious_kpoints/Si.pbe-n-rrkjus_psl.1.0.0.UPF
+++ b/tests/fixtures/preflight/suspicious_kpoints/Si.pbe-n-rrkjus_psl.1.0.0.UPF
@@ -1,0 +1,4 @@
+<UPF version="2.0.1">
+Stub pseudopotential for the qe-lsp preflight regression fixture.
+<PP_INFO generated="qe-lsp-preflight-fixture" />
+</UPF>

--- a/tests/fixtures/preflight/suspicious_kpoints/pw.in
+++ b/tests/fixtures/preflight/suspicious_kpoints/pw.in
@@ -1,0 +1,26 @@
+&CONTROL
+  calculation = 'scf'
+  prefix = 'si'
+  pseudo_dir = './'
+/
+&SYSTEM
+  ibrav = 0
+  nat = 2
+  ntyp = 1
+  ecutwfc = 60.0
+  ecutrho = 480.0
+/
+&ELECTRONS
+  conv_thr = 1.0d-8
+/
+ATOMIC_SPECIES
+  Si 28.0855 Si.pbe-n-rrkjus_psl.1.0.0.UPF
+ATOMIC_POSITIONS crystal
+  Si 0.00 0.00 0.00
+  Si 0.25 0.25 0.25
+K_POINTS automatic
+  1 4 4 0 0 0
+CELL_PARAMETERS angstrom
+  0.000 2.715 2.715
+  2.715 0.000 2.715
+  2.715 2.715 0.000

--- a/tests/fixtures/preflight/valid_pw/.qe-lsp/fixtures.json
+++ b/tests/fixtures/preflight/valid_pw/.qe-lsp/fixtures.json
@@ -1,0 +1,52 @@
+{
+  "fixtures": [
+    {
+      "name": "valid_pw",
+      "path": "tests/fixtures/preflight/valid_pw",
+      "expect_ok": true,
+      "expect_codes": []
+    },
+    {
+      "name": "ntyp_mismatch",
+      "path": "tests/fixtures/preflight/ntyp_mismatch",
+      "expect_ok": false,
+      "expect_codes": ["QE604"]
+    },
+    {
+      "name": "missing_cell_parameters",
+      "path": "tests/fixtures/preflight/missing_cell_parameters",
+      "expect_ok": false,
+      "expect_codes": ["QE603"]
+    },
+    {
+      "name": "missing_pseudos",
+      "path": "tests/fixtures/preflight/missing_pseudos",
+      "expect_ok": false,
+      "expect_codes": ["QE606"]
+    },
+    {
+      "name": "low_ecutwfc",
+      "path": "tests/fixtures/preflight/low_ecutwfc",
+      "expect_ok": true,
+      "expect_codes": ["QE607"]
+    },
+    {
+      "name": "suspicious_kpoints",
+      "path": "tests/fixtures/preflight/suspicious_kpoints",
+      "expect_ok": true,
+      "expect_codes": ["QE608"]
+    },
+    {
+      "name": "missing_kpoints",
+      "path": "tests/fixtures/preflight/missing_kpoints",
+      "expect_ok": true,
+      "expect_codes": ["QE608"]
+    },
+    {
+      "name": "keyword_version_mismatch",
+      "path": "tests/fixtures/preflight/keyword_version_mismatch",
+      "expect_ok": false,
+      "expect_codes": ["QE610"]
+    }
+  ]
+}

--- a/tests/fixtures/preflight/valid_pw/.qe-lsp/intent.json
+++ b/tests/fixtures/preflight/valid_pw/.qe-lsp/intent.json
@@ -1,0 +1,4 @@
+{
+  "software_version": "qe >=7.0",
+  "schema_source": "qe-lsp builtin"
+}

--- a/tests/fixtures/preflight/valid_pw/Si.pbe-n-rrkjus_psl.1.0.0.UPF
+++ b/tests/fixtures/preflight/valid_pw/Si.pbe-n-rrkjus_psl.1.0.0.UPF
@@ -1,0 +1,8 @@
+<UPF version="2.0.1">
+A minimal stub pseudopotential file for the qe-lsp preflight regression
+fixture. It exists only so the cross-artifact graph can mark the referenced
+pseudopotential as resolved; it is NOT a real, usable pseudopotential.
+<PP_INFO>
+generated="qe-lsp-preflight-fixture"
+</PP_INFO>
+</UPF>

--- a/tests/fixtures/preflight/valid_pw/pw.in
+++ b/tests/fixtures/preflight/valid_pw/pw.in
@@ -1,0 +1,26 @@
+&CONTROL
+  calculation = 'scf'
+  prefix = 'si'
+  pseudo_dir = './'
+/
+&SYSTEM
+  ibrav = 0
+  nat = 2
+  ntyp = 1
+  ecutwfc = 60.0
+  ecutrho = 480.0
+/
+&ELECTRONS
+  conv_thr = 1.0d-8
+/
+ATOMIC_SPECIES
+  Si 28.0855 Si.pbe-n-rrkjus_psl.1.0.0.UPF
+ATOMIC_POSITIONS crystal
+  Si 0.00 0.00 0.00
+  Si 0.25 0.25 0.25
+K_POINTS automatic
+  4 4 4 0 0 0
+CELL_PARAMETERS angstrom
+  0.000 2.715 2.715
+  2.715 0.000 2.715
+  2.715 2.715 0.000

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from qe_lsp import tool
+from qe_lsp.preflight import (
+    ALL_ROLES,
+    CODE_LOW_ECUTWFC,
+    CODE_MISSING_INPUT,
+    CODE_MISSING_LATTICE,
+    CODE_MISSING_PSEUDOS,
+    CODE_MISSING_STRUCTURE,
+    CODE_NTYP_SPECIES_MISMATCH,
+    CODE_SUSPICIOUS_KPOINTS,
+    CODE_UNKNOWN_KEYWORD_VERSION,
+    CODE_UNRESOLVED_PSEUDO,
+    CODE_VERSION_ASSUMPTION,
+    DEFAULT_ECUTWFC_WARNING_RY,
+    ArtifactGraph,
+    build_artifact_graph,
+    fleet_manifest,
+    resolve_version_assumption,
+)
+from qe_lsp.tool import (
+    _looks_like_workspace,
+    check_path,
+    manifest_path,
+    preflight_path,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "preflight"
+
+# Envelope fields the issue acceptance criteria require on failing fixtures.
+REQUIRED_FAILING_FIELDS = {
+    "code",
+    "severity",
+    "path",
+    "range",
+    "blocking",
+    "category",
+    "source_provenance",
+}
+
+
+def _envelope_codes(payload: dict) -> set[str]:
+    return {item["code"] for item in payload["diagnostics"]}
+
+
+# --- Envelope shape --------------------------------------------------------
+
+
+def test_agent_check_payload_carries_diagnostic_envelope_v1(capsys) -> None:
+    # exercise the real CLI path so the capabilities block is attached
+    rc = tool.main(["check", str(FIXTURES / "ntyp_mismatch")])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["diagnostic_envelope"] == "v1"
+    assert payload["diagnostic_engine"] == "1.0"
+    assert payload["software"] == "qe"
+    # capabilities block is attached by the CLI wrapper
+    assert payload["capabilities"]["operation"] == "check"
+    # version assumption is surfaced at top level so the parent probe can branch
+    assert "version_assumption" in payload
+    assert payload["version_assumption"]["software"] == "qe"
+    # cross-artifact graph is serialized for the fleet report workflow
+    assert isinstance(payload.get("artifacts"), list)
+    assert payload["artifacts"]
+
+
+def test_failing_diagnostics_carry_required_envelope_fields() -> None:
+    payload = preflight_path(FIXTURES / "ntyp_mismatch")
+    failing = [
+        item for item in payload["diagnostics"] if item["code"] == CODE_NTYP_SPECIES_MISMATCH
+    ]
+    assert failing, "ntyp mismatch fixture must emit QE604"
+    item = failing[0]
+    for field in REQUIRED_FAILING_FIELDS:
+        assert field in item, f"missing required envelope field: {field}"
+    # Richer envelope fields used by the parent fleet probe
+    assert item["confidence"] >= 0.0
+    assert "actions" in item and item["actions"]
+    assert "fix_hints" in item and item["fix_hints"]
+    assert "facts" in item
+    assert item["facts"]["declared_ntyp"] == 1
+    assert item["facts"]["species_count"] == 2
+    assert "artifact_roles" in item
+    # range is a proper LSP-style start/end object
+    assert item["range"]["start"]["line"] >= 0
+    assert "character" in item["range"]["start"]
+
+
+# --- Fixture behavior ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture, expected_ok, must_include",
+    [
+        ("valid_pw", True, set()),
+        ("ntyp_mismatch", False, {CODE_NTYP_SPECIES_MISMATCH}),
+        ("missing_cell_parameters", False, {CODE_MISSING_LATTICE}),
+        ("missing_pseudos", False, {CODE_MISSING_PSEUDOS}),
+        ("low_ecutwfc", True, {CODE_LOW_ECUTWFC}),
+        ("suspicious_kpoints", True, {CODE_SUSPICIOUS_KPOINTS}),
+        ("missing_kpoints", True, {CODE_SUSPICIOUS_KPOINTS}),
+        ("keyword_version_mismatch", False, {CODE_UNKNOWN_KEYWORD_VERSION}),
+    ],
+)
+def test_preflight_fixture_expectations(
+    fixture: str,
+    expected_ok: bool,
+    must_include: set[str],
+) -> None:
+    payload = preflight_path(FIXTURES / fixture)
+    codes = _envelope_codes(payload)
+    assert (
+        payload["ok"] is expected_ok
+    ), f"{fixture}: expected ok={expected_ok}, got codes={sorted(codes)}"
+    assert must_include <= codes, f"{fixture}: expected codes {must_include}, got {sorted(codes)}"
+
+
+def test_valid_pw_fixture_has_no_blocking_or_error_diagnostics() -> None:
+    payload = preflight_path(FIXTURES / "valid_pw")
+    assert payload["summary"]["errors"] == 0
+    assert payload["summary"]["blocking"] == 0
+    # valid fixture must not carry the preflight error codes
+    error_codes = {
+        CODE_MISSING_INPUT,
+        CODE_MISSING_STRUCTURE,
+        CODE_MISSING_LATTICE,
+        CODE_NTYP_SPECIES_MISMATCH,
+        CODE_MISSING_PSEUDOS,
+        CODE_UNKNOWN_KEYWORD_VERSION,
+    }
+    assert not (_envelope_codes(payload) & error_codes)
+
+
+def test_low_ecutwfc_is_non_blocking_warning_with_threshold_fact() -> None:
+    payload = preflight_path(FIXTURES / "low_ecutwfc")
+    item = next(d for d in payload["diagnostics"] if d["code"] == CODE_LOW_ECUTWFC)
+    assert item["severity"] == "warning"
+    assert item["blocking"] is False
+    assert item["facts"]["ecutwfc"] == 20.0
+    assert item["facts"]["threshold"] == DEFAULT_ECUTWFC_WARNING_RY
+
+
+def test_low_ecutwfc_intent_override_changes_threshold(tmp_path: Path) -> None:
+    case = tmp_path / "case"
+    case.mkdir()
+    (case / "pw.in").write_text(
+        "&CONTROL\n/\n&SYSTEM\n  ibrav = 0\n  nat = 1\n  ntyp = 1\n  ecutwfc = 40\n/\n"
+        "&ELECTRONS\n/\n"
+        "ATOMIC_SPECIES\n  Si 28.085 Si.UPF\n"
+        "ATOMIC_POSITIONS crystal\n  Si 0.0 0.0 0.0\n"
+        "K_POINTS automatic\n  4 4 4 0 0 0\n"
+        "CELL_PARAMETERS angstrom\n  1 0 0\n  0 1 0\n  0 0 1\n",
+        encoding="utf-8",
+    )
+    (case / "Si.UPF").write_text("<UPF/>", encoding="utf-8")
+    # No intent: default threshold 50 -> ecutwfc 40 is below -> warning fires.
+    base = preflight_path(case)
+    assert CODE_LOW_ECUTWFC in _envelope_codes(base)
+
+    cfg = case / ".qe-lsp"
+    cfg.mkdir()
+    (cfg / "intent.json").write_text(json.dumps({"ecutwfc_warning_ry": 30.0}), encoding="utf-8")
+    overridden = preflight_path(case)
+    assert CODE_LOW_ECUTWFC not in _envelope_codes(overridden)
+
+
+# --- version-aware-keywords ------------------------------------------------
+
+
+def test_version_assumption_unknown_when_intent_absent() -> None:
+    assumption = resolve_version_assumption(None)
+    assert assumption["exact_runtime_known"] is False
+    assert assumption["declared_by"] == "fallback"
+    assert assumption["software_version"] == "unknown"
+
+
+def test_version_assumption_known_when_intent_declares_version() -> None:
+    assumption = resolve_version_assumption(
+        {"software_version": "qe >=7.2", "runtime_image": "img:7.2"}
+    )
+    assert assumption["exact_runtime_known"] is True
+    assert assumption["declared_by"] == "intent"
+    assert assumption["software_version"] == "qe >=7.2"
+
+
+def test_version_assumption_information_diagnostic_when_unknown(tmp_path: Path) -> None:
+    case = tmp_path / "case"
+    case.mkdir()
+    (case / "pw.in").write_text(
+        "&CONTROL\n/\n&SYSTEM\n  ibrav = 0\n  nat = 1\n  ntyp = 1\n  ecutwfc = 80\n/\n"
+        "&ELECTRONS\n/\n"
+        "ATOMIC_SPECIES\n  Si 28.085 Si.UPF\n"
+        "ATOMIC_POSITIONS crystal\n  Si 0.0 0.0 0.0\n"
+        "K_POINTS automatic\n  4 4 4 0 0 0\n"
+        "CELL_PARAMETERS angstrom\n  1 0 0\n  0 1 0\n  0 0 1\n",
+        encoding="utf-8",
+    )
+    (case / "Si.UPF").write_text("<UPF/>", encoding="utf-8")
+    payload = preflight_path(case)
+    item = next(
+        (d for d in payload["diagnostics"] if d["code"] == CODE_VERSION_ASSUMPTION),
+        None,
+    )
+    assert item is not None
+    assert item["severity"] == "information"
+    assert item["blocking"] is False
+    assert item["version_assumption"]["exact_runtime_known"] is False
+
+
+def test_version_assumption_silent_when_intent_declares_version(tmp_path: Path) -> None:
+    case = tmp_path / "case"
+    case.mkdir()
+    (case / "pw.in").write_text(
+        "&CONTROL\n/\n&SYSTEM\n  ibrav = 0\n  nat = 1\n  ntyp = 1\n  ecutwfc = 80\n/\n"
+        "&ELECTRONS\n/\n"
+        "ATOMIC_SPECIES\n  Si 28.085 Si.UPF\n"
+        "ATOMIC_POSITIONS crystal\n  Si 0.0 0.0 0.0\n"
+        "K_POINTS automatic\n  4 4 4 0 0 0\n"
+        "CELL_PARAMETERS angstrom\n  1 0 0\n  0 1 0\n  0 0 1\n",
+        encoding="utf-8",
+    )
+    (case / "Si.UPF").write_text("<UPF/>", encoding="utf-8")
+    cfg = case / ".qe-lsp"
+    cfg.mkdir()
+    (cfg / "intent.json").write_text(json.dumps({"software_version": "qe >=7.2"}), encoding="utf-8")
+    payload = preflight_path(case)
+    assert CODE_VERSION_ASSUMPTION not in _envelope_codes(payload)
+    assert payload["version_assumption"]["exact_runtime_known"] is True
+
+
+def test_keyword_version_mismatch_carries_version_assumption() -> None:
+    payload = preflight_path(FIXTURES / "keyword_version_mismatch")
+    item = next(d for d in payload["diagnostics"] if d["code"] == CODE_UNKNOWN_KEYWORD_VERSION)
+    # The fixture declares qe >=5.0 and uses `gate`, which requires >=6.4.
+    assert item["facts"]["keyword"] == "gate"
+    assert item["facts"]["required_version"] == "qe >=6.4"
+    assert "version-aware" in item["domain_tags"]
+    assert "version_assumption" in item
+
+
+# --- cross-artifact-graph --------------------------------------------------
+
+
+def test_artifact_graph_uses_generic_roles() -> None:
+    from qe_lsp.parser import parse_qe_input
+
+    case_dir = (FIXTURES / "valid_pw").resolve()
+    text = (case_dir / "pw.in").read_text(encoding="utf-8")
+    parsed = parse_qe_input(text)
+    graph = build_artifact_graph(case_dir, parsed, case_dir / "pw.in")
+    roles = {node.role for node in graph.nodes}
+    assert roles <= set(ALL_ROLES)
+    # primary-input, structure, kpoints, lattice are always present
+    for required in ("primary-input", "structure", "kpoints", "lattice"):
+        assert graph.by_role(required), f"missing required role: {required}"
+    # serialized graph is JSON-friendly and stable
+    serialized = graph.to_json()
+    assert isinstance(serialized, list)
+    assert all("role" in node and "path" in node and "exists" in node for node in serialized)
+
+
+def test_missing_lattice_records_ibrav_fact() -> None:
+    payload = preflight_path(FIXTURES / "missing_cell_parameters")
+    item = next(d for d in payload["diagnostics"] if d["code"] == CODE_MISSING_LATTICE)
+    prov = item["source_provenance"]
+    assert prov["role"] == "lattice"
+    # ibrav=0 was the declared free-cell mode
+    assert item["facts"]["ibrav"] == 0
+
+
+def test_unresolved_pseudopotential_is_warning(tmp_path: Path) -> None:
+    case = tmp_path / "case"
+    case.mkdir()
+    (case / "pw.in").write_text(
+        "&CONTROL\n  pseudo_dir = './'\n/\n&SYSTEM\n  ibrav = 0\n  nat = 1\n  ntyp = 1\n"
+        "  ecutwfc = 80\n/\n&ELECTRONS\n/\n"
+        "ATOMIC_SPECIES\n  Si 28.085 Si_missing.UPF\n"
+        "ATOMIC_POSITIONS crystal\n  Si 0.0 0.0 0.0\n"
+        "K_POINTS automatic\n  4 4 4 0 0 0\n"
+        "CELL_PARAMETERS angstrom\n  1 0 0\n  0 1 0\n  0 0 1\n",
+        encoding="utf-8",
+    )
+    payload = preflight_path(case)
+    item = next(
+        (d for d in payload["diagnostics"] if d["code"] == CODE_UNRESOLVED_PSEUDO),
+        None,
+    )
+    assert item is not None
+    assert item["severity"] == "warning"
+    assert item["artifact_roles"] == ["pseudopotential"]
+
+
+def test_suspicious_kpoints_warning_on_single_point_axis() -> None:
+    payload = preflight_path(FIXTURES / "suspicious_kpoints")
+    item = next(
+        (d for d in payload["diagnostics"] if d["code"] == CODE_SUSPICIOUS_KPOINTS),
+        None,
+    )
+    assert item is not None
+    assert item["severity"] == "warning"
+    assert item["facts"]["grid"] == [1, 4, 4]
+
+
+def test_missing_kpoints_card_emits_non_blocking_warning() -> None:
+    payload = preflight_path(FIXTURES / "missing_kpoints")
+    item = next(
+        (d for d in payload["diagnostics"] if d["code"] == CODE_SUSPICIOUS_KPOINTS),
+        None,
+    )
+    assert item is not None
+    assert item["severity"] == "warning"
+    assert item["blocking"] is False
+
+
+def test_missing_primary_input_emits_blocking_finding(tmp_path: Path) -> None:
+    case = tmp_path / "empty"
+    case.mkdir()
+    payload = preflight_path(case)
+    item = next(
+        (d for d in payload["diagnostics"] if d["code"] == CODE_MISSING_INPUT),
+        None,
+    )
+    assert item is not None
+    assert item["severity"] == "error"
+    assert item["blocking"] is True
+
+
+# --- code-actions / blocking gate -----------------------------------------
+
+
+def test_check_fail_on_blocking_exits_nonzero_on_failing_fixture() -> None:
+    rc = tool.main(["check", str(FIXTURES / "ntyp_mismatch"), "--fail-on-blocking"])
+    assert rc == 1
+
+
+def test_check_fail_on_blocking_exits_zero_on_valid_fixture(capsys) -> None:
+    rc = tool.main(["check", str(FIXTURES / "valid_pw"), "--fail-on-blocking"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+
+
+def test_preflight_subcommand_emits_envelope(capsys) -> None:
+    rc = tool.main(["preflight", str(FIXTURES / "low_ecutwfc")])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["operation"] == "preflight"
+    assert payload["diagnostic_envelope"] == "v1"
+    assert payload["capabilities"]["operation"] == "preflight"
+
+
+def test_preflight_fail_on_blocking_exits_nonzero() -> None:
+    rc = tool.main(["preflight", str(FIXTURES / "ntyp_mismatch"), "--fail-on-blocking"])
+    assert rc == 1
+
+
+def test_actions_present_on_blocking_diagnostics() -> None:
+    payload = preflight_path(FIXTURES / "ntyp_mismatch")
+    blocking = [d for d in payload["diagnostics"] if d["blocking"]]
+    assert blocking
+    for item in blocking:
+        assert item.get("actions"), f"blocking diagnostic {item['code']} must carry actions"
+        assert all("kind" in action for action in item["actions"])
+
+
+# --- fleet-regression-fixtures / manifest ---------------------------------
+
+
+def test_manifest_lists_all_four_capabilities() -> None:
+    manifest = manifest_path(FIXTURES / "valid_pw")
+    capabilities = manifest["capabilities"]
+    for cap in (
+        "version-aware-keywords",
+        "cross-artifact-graph",
+        "code-actions",
+        "fleet-regression-fixtures",
+    ):
+        assert cap in capabilities, f"missing capability: {cap}"
+        assert capabilities[cap]["status"] == "available"
+    # artifact roles are the generic fleet model, not MatMaster policy
+    assert set(manifest["artifact_roles"]) == set(ALL_ROLES)
+    assert manifest["preflight_envelope"] == "DiagnosticEnvelope/v1"
+
+
+def test_manifest_without_path_still_describes_surface() -> None:
+    manifest = manifest_path(None)
+    assert set(manifest["codes"])
+    assert manifest["capabilities"]["code-actions"]["blocking_gate"]
+
+
+def test_manifest_merges_fixture_expectations() -> None:
+    manifest = manifest_path(FIXTURES / "valid_pw")
+    fixtures = manifest["capabilities"]["fleet-regression-fixtures"]["fixtures"]
+    names = {item["name"] for item in fixtures}
+    assert {
+        "valid_pw",
+        "ntyp_mismatch",
+        "missing_cell_parameters",
+        "missing_pseudos",
+        "low_ecutwfc",
+        "suspicious_kpoints",
+        "missing_kpoints",
+        "keyword_version_mismatch",
+    } <= names
+
+
+def test_fleet_manifest_helper_pure_data() -> None:
+    manifest = fleet_manifest(fixtures=[{"name": "x", "expect_ok": True}])
+    assert manifest["capabilities"]["fleet-regression-fixtures"]["fixtures"] == [
+        {"name": "x", "expect_ok": True}
+    ]
+    # every code entry is self-describing for the parent probe
+    for body in manifest["codes"].values():
+        assert body["severity"] in {"error", "warning", "information", "hint"}
+        assert "capability" in body
+        assert "summary" in body
+
+
+def test_fixture_expectations_match_actual_preflight() -> None:
+    """The fleet manifest's declared fixture expectations must match reality.
+
+    This is the regression-evidence contract: the parent ``bohrium_skills``
+    probe consumes the manifest and replays these fixtures, so the declared
+    expectations have to agree with what the preflight actually emits.
+    """
+    manifest = manifest_path(FIXTURES / "valid_pw")
+    repo_root = Path(__file__).resolve().parent.parent
+    for fixture in manifest["capabilities"]["fleet-regression-fixtures"]["fixtures"]:
+        payload = preflight_path(repo_root / fixture["path"])
+        assert payload["ok"] is fixture["expect_ok"], (
+            f"{fixture['name']}: manifest expects ok={fixture['expect_ok']}, "
+            f"got ok={payload['ok']}"
+        )
+        if fixture["expect_codes"]:
+            assert set(fixture["expect_codes"]) <= _envelope_codes(payload), (
+                f"{fixture['name']}: expected codes {fixture['expect_codes']}, "
+                f"got {sorted(_envelope_codes(payload))}"
+            )
+
+
+# --- workspace detection ---------------------------------------------------
+
+
+def test_looks_like_workspace_requires_qe_input(tmp_path: Path) -> None:
+    assert _looks_like_workspace(tmp_path) is False
+    (tmp_path / "pw.in").write_text("&CONTROL\n/\n", encoding="utf-8")
+    assert _looks_like_workspace(tmp_path) is True
+
+
+def test_check_on_single_input_file_does_not_run_preflight(tmp_path: Path) -> None:
+    # A bare pw.in with no case-directory context must keep the legacy
+    # single-file behavior and NOT flood with blocking missing-artifact
+    # preflight errors.
+    input_path = tmp_path / "pw.in"
+    input_path.write_text("&CONTROL\n/\n", encoding="utf-8")
+    payload = check_path(input_path)
+    preflight_codes = {
+        CODE_MISSING_INPUT,
+        CODE_MISSING_STRUCTURE,
+        CODE_MISSING_LATTICE,
+    }
+    assert not (_envelope_codes(payload) & preflight_codes)
+
+
+def test_check_on_full_workspace_merges_preflight() -> None:
+    payload = check_path(FIXTURES / "ntyp_mismatch")
+    codes = _envelope_codes(payload)
+    assert CODE_NTYP_SPECIES_MISMATCH in codes
+    assert payload["diagnostic_envelope"] == "v1"
+
+
+def test_artifact_graph_is_json_serializable_for_fleet_report() -> None:
+    payload = preflight_path(FIXTURES / "valid_pw")
+    # artifacts must round-trip through json.dumps cleanly for the parent probe
+    serialized = json.dumps(payload["artifacts"], sort_keys=True)
+    assert "primary-input" in serialized
+    assert "structure" in serialized
+
+
+def test_artifact_graph_class_smoke() -> None:
+    graph = ArtifactGraph(case_dir=Path("/tmp"))
+    assert graph.nodes == []
+    assert graph.by_role("structure") == []
+    assert graph.to_json() == []


### PR DESCRIPTION
Closes #85

Mirrors the proven preflight capability model from the sibling fleet backends (abacus-lsp #60/#62, abinit-lsp #32/#34, gamess-lsp #82/#83) onto qe-lsp, adapted to the Quantum ESPRESSO pw.x domain. Implements the four generic capabilities from issue #85 against a generic artifact-role model (not MatMaster-specific policy).

## What changed

- `src/qe_lsp/preflight.py` (new): the four capabilities + cross-artifact graph + `fleet_manifest`.
- `src/qe_lsp/rich_diagnostics.py`: `DiagnosticEnvelope/v1` normalization (backward-compatible with the legacy `diagnostic_engine "1.0"` label). `agent_check_payload` now surfaces `intent`/`version_assumption`/`artifacts` at the top level when evidenced.
- `src/qe_lsp/tool.py`: `preflight` and `manifest` subcommands, `check --fail-on-blocking`/`preflight --fail-on-blocking` gate, case-directory workspace detection, `.qe-lsp/intent.json` + `.qe-lsp/fixtures.json` loading. `_collect_diagnostics` guards the directory path so the legacy single-file providers are skipped for case directories.
- `tests/test_preflight.py` (new): 39 focused tests.
- `tests/fixtures/preflight/`: 8 fixtures (1 valid + 7 failing/warning).

## QE domain mapping

QE pw.x inputs map onto the same generic artifact-role set the rest of the fleet uses, so the parent router consumes them without learning MatMaster/QE specifics:

- `primary-input` → the `.pwi`/`.in` pw.x input file
- `structure` → `ATOMIC_POSITIONS` card (+ `nat`/`ntyp` in `&SYSTEM`)
- `kpoints` → `K_POINTS` card
- `lattice` → `CELL_PARAMETERS` card (when `ibrav=0`) or `ibrav>0`+`celldm`/`a`
- `pseudopotential` → external `.UPF` files referenced per species in `ATOMIC_SPECIES` (the only true cross-file artifact)
- `orbital` → reserved for fleet role consistency; not populated for QE (PW basis)

## Preflight codes (QE6xx band)

| Code | Capability | Severity | Blocking | Summary |
|------|-----------|----------|----------|---------|
| QE601 | cross-artifact-graph | error | yes | primary-input artifact missing |
| QE602 | cross-artifact-graph | error | yes | ATOMIC_POSITIONS / &SYSTEM structure missing |
| QE603 | cross-artifact-graph | error | yes | ibrav=0 without CELL_PARAMETERS |
| QE604 | cross-artifact-graph | error | yes | ntyp vs ATOMIC_SPECIES row mismatch |
| QE605 | cross-artifact-graph | warning | no | pseudopotential file cannot be resolved |
| QE606 | cross-artifact-graph | error | yes | structure declared but no pseudo filenames |
| QE607 | version-aware-keywords | warning | no | ecutwfc below conservative threshold |
| QE608 | cross-artifact-graph | warning | no | k-point grid has a 1-point axis or is undeclared |
| QE609 | version-aware-keywords | information | no | exact runtime version unknown; fallback schema |
| QE610 | version-aware-keywords | error | yes | keyword requires newer runtime than declared |

## Acceptance criteria mapping

- ✅ **Backend emits normalized `DiagnosticEnvelope/v1` through its agent CLI or router path** — `qe-lsp-tool check`/`preflight` emit `diagnostic_envelope: "v1"` (CLI smoke-verified; `tests/test_preflight.py::test_agent_check_payload_carries_diagnostic_envelope_v1`).
- ✅ **At least one valid fixture and one failing fixture** — `valid_pw` (ok=true) + 7 failing/warning fixtures under `tests/fixtures/preflight/`.
- ✅ **Failing fixtures include `code`, `severity`, `path`/`range`, `blocking`, `category`, `source_provenance`, and `fix_hints`/`actions`** — asserted by `tests/test_preflight.py::test_failing_diagnostics_carry_required_envelope_fields` and verified on the real QE604 emission.
- ✅ **Version assumptions are explicit** — `resolve_version_assumption` records `software`/`software_version`/`runtime_image`/`schema_source`/`exact_runtime_known`/`declared_by`; surfaced at the envelope top level and as a QE609 information diagnostic; overridable via `.qe-lsp/intent.json`.
- ✅ **Cross-file/cross-artifact checks use a generic artifact-role model, not MatMaster policy** — `ALL_ROLES` is the fleet-generic set; `fleet_manifest()["artifact_roles"]` asserts equality; `tests/test_preflight.py::test_artifact_graph_uses_generic_roles`.
- ✅ **Fleet regression evidence consumable by the parent `bohrium_skills` probe** — `qe-lsp-tool manifest` emits machine-readable codes/capabilities/roles + merged fixture expectations; `tests/test_preflight.py::test_fixture_expectations_match_actual_preflight` is the regression-evidence contract.

## Test Plan

- `make check` locally: **ruff** clean, **mypy src** clean (no issues in 32 source files), **pytest** 634 passed (39 new in `tests/test_preflight.py`), coverage gate (≥80%) reached.
- **black --check src tests**: clean.
- **pre-commit run --all-files**: all hooks pass (trailing-ws, eof, yaml/json/toml, black, ruff, mypy).
- CLI smoke: `qe-lsp-tool preflight <fixture>`, `qe-lsp-tool manifest <fixture>`, and `qe-lsp-tool check <fixture> --fail-on-blocking` (exit 1 on failing fixtures, 0 on `valid_pw`) all behave as expected.
- Local `mypy src tests` shows a pre-existing environment artifact (mypy follows imports into the locally-installed `_pytest` which uses py3.10 match statements under a py3.9 mypy target); this reproduces on the clean base branch without these changes and does not affect CI, which runs mypy on a fresh py3.12 environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)