### PR TITLE
feat(#92): add closed-loop fixture CLI coverage

### DIFF
--- a/tests/fixtures/invalid/atomic_positions_without_species.in
+++ b/tests/fixtures/invalid/atomic_positions_without_species.in
@@ -1,0 +1,19 @@
+&CONTROL
+  calculation = 'scf'
+/
+&SYSTEM
+  ibrav = 2
+  celldm(1) = 10.26
+  nat = 2
+  ntyp = 1
+  ecutwfc = 30.0
+/
+&ELECTRONS
+/
+ATOMIC_SPECIES
+O 15.999 O.pbe.UPF
+ATOMIC_POSITIONS {crystal}
+Si 0.00 0.00 0.00
+Si 0.25 0.25 0.25
+K_POINTS {automatic}
+8 8 8 0 0 0

--- a/tests/fixtures/invalid/gamma_nonzero_offset.in
+++ b/tests/fixtures/invalid/gamma_nonzero_offset.in
@@ -1,0 +1,19 @@
+&CONTROL
+  calculation = 'scf'
+/
+&SYSTEM
+  ibrav = 2
+  celldm(1) = 10.26
+  nat = 2
+  ntyp = 1
+  ecutwfc = 30.0
+/
+&ELECTRONS
+/
+ATOMIC_SPECIES
+Si 28.086 Si.pbe-n-rrkjus_psl.1.0.0.UPF
+ATOMIC_POSITIONS {crystal}
+Si 0.00 0.00 0.00
+Si 0.25 0.25 0.25
+K_POINTS {gamma}
+1 1 1 0 0 1

--- a/tests/fixtures/invalid/low_ecutrho_ratio.in
+++ b/tests/fixtures/invalid/low_ecutrho_ratio.in
@@ -1,0 +1,21 @@
+&CONTROL
+  calculation = 'scf'
+/
+&SYSTEM
+  ibrav = 2
+  celldm(1) = 10.26
+  nat = 2
+  ntyp = 1
+  ecutwfc = 30.0
+  ecutrho = 100.0
+/
+&ELECTRONS
+  conv_thr = 1.0d-8
+/
+ATOMIC_SPECIES
+Si 28.086 Si.pbe-n-rrkjus_psl.1.0.0.UPF
+ATOMIC_POSITIONS {crystal}
+Si 0.00 0.00 0.00
+Si 0.25 0.25 0.25
+K_POINTS {automatic}
+8 8 8 0 0 0

--- a/tests/fixtures/invalid/missing_cell_parameters.in
+++ b/tests/fixtures/invalid/missing_cell_parameters.in
@@ -1,0 +1,18 @@
+&CONTROL
+  calculation = 'scf'
+/
+&SYSTEM
+  ibrav = 0
+  nat = 2
+  ntyp = 1
+  ecutwfc = 30.0
+/
+&ELECTRONS
+/
+ATOMIC_SPECIES
+Si 28.086 Si.pbe-n-rrkjus_psl.1.0.0.UPF
+ATOMIC_POSITIONS crystal
+Si 0.00 0.00 0.00
+Si 0.25 0.25 0.25
+K_POINTS automatic
+4 4 4 0 0 0

--- a/tests/fixtures/invalid/pseudo_element_mismatch.in
+++ b/tests/fixtures/invalid/pseudo_element_mismatch.in
@@ -1,0 +1,19 @@
+&CONTROL
+  calculation = 'scf'
+/
+&SYSTEM
+  ibrav = 2
+  celldm(1) = 10.26
+  nat = 2
+  ntyp = 1
+  ecutwfc = 30.0
+/
+&ELECTRONS
+/
+ATOMIC_SPECIES
+O 15.999 Si.pbe-n-rrkjus_psl.1.0.0.UPF
+ATOMIC_POSITIONS {crystal}
+Si 0.00 0.00 0.00
+Si 0.25 0.25 0.25
+K_POINTS {automatic}
+8 8 8 0 0 0

--- a/tests/fixtures/invalid/unclosed_namelist.in
+++ b/tests/fixtures/invalid/unclosed_namelist.in
@@ -1,0 +1,2 @@
+&CONTROL
+  calculation = 'scf'

--- a/tests/fixtures/logs/ecutrho_warning.log
+++ b/tests/fixtures/logs/ecutrho_warning.log
@@ -1,0 +1,55 @@
+Program pw.x v.7.2 starts on 15Jun2026 at 10:00:00
+
+     Program PATH: /usr/local/bin/pw.x
+     Hostname: localhost
+
+     Current dimensions of program pw:
+     natx    =      1000
+     ntypx   =        10
+     npwx    =      1000
+     nbnd    =        20
+     npol    =         1
+     npsa    =         1
+
+     bravais-lattice index =    2
+     lattice parameter (alat)  =  10.2600  a.u.
+     unit-cell volume          = 543.0936 (a.u.)^3
+
+     number of atoms/cell =    2
+     number of atomic types    =    1
+     number of Kohn-Sham states =    10
+
+     kinetic-energy cutoff     =   30.0000  Ry
+     charge density cutoff     =  120.0000  Ry
+     convergence threshold     =   1.0E-08
+
+     WARNING: ecutrho should be at least 4x ecutwfc (120.0 < 120.0)
+
+     Electron dynamics: steepest-descent
+
+     Writing output data to ./tmp/
+
+     init_run     :      0.07s CPU      0.08s WALL
+
+     total   pseudopotential    local   ultrasoft(paw)      beta
+     Rcut(pseudopotential) =    2.30  2.30  2.30  2.30  2.30 a.u.
+     Rcut(ultrasoft)       =    2.30  2.30  2.30  2.30  2.30 a.u.
+
+     Ewald energy           =       0.00000000 Ry
+     Hartree energy         =       0.00000000 Ry
+     XC energy              =       0.00000000 Ry
+     local contribution     =       0.00000000 Ry
+     non-local contribution =       0.00000000 Ry
+     total energy           =       0.00000000 Ry
+
+     SCF iterations:    1
+     total time          =      0.10s CPU      0.12s WALL
+
+     Writing wavefunctions to ./tmp/
+
+     init_run     :      0.07s CPU      0.08s WALL
+     electrons    :      0.10s CPU      0.12s WALL
+
+     PWSCF        :      0.17s CPU      0.20s WALL
+
+     This run was terminated on: 10:00:01  15Jun2026

--- a/tests/fixtures/logs/scf_converged.log
+++ b/tests/fixtures/logs/scf_converged.log
@@ -1,0 +1,75 @@
+Program pw.x v.7.2 starts on 15Jun2026 at 10:00:00
+
+     Program PATH: /usr/local/bin/pw.x
+     Hostname: localhost
+
+     Current dimensions of program pw:
+     natx    =      1000
+     ntypx   =        10
+     npwx    =      1000
+     nbnd    =        20
+     npol    =         1
+     npsa    =         1
+
+     gamma-only: only 1 k-point
+
+     bravais-lattice index =    2
+     lattice parameter (alat)  =  10.2600  a.u.
+     unit-cell volume          = 543.0936 (a.u.)^3
+
+     number of atoms/cell =    2
+     number of atomic types    =    1
+     number of Kohn-Sham states =    10
+
+     kinetic-energy cutoff     =   30.0000  Ry
+     charge density cutoff     =  240.0000  Ry
+     convergence threshold     =   1.0E-08
+
+     Electron dynamics: steepest-descent
+
+     Methyl group rotation: not used
+
+     Writing output data to ./tmp/
+
+     init_run     :      0.07s CPU      0.08s WALL
+
+     total   pseudopotential    local   ultrasoft(paw)      beta
+     Rcut(pseudopotential) =    2.30  2.30  2.30  2.30  2.30 a.u.
+     Rcut(ultrasoft)       =    2.30  2.30  2.30  2.30  2.30 a.u.
+     Rho(n)=1.00 Rcut =    2.30 a.u.
+
+     Parallel ground-state structure factors:
+     number of processors       =      1
+     number of FFTs (combined)  =      1
+
+     Task   0 of    1 is assigned to   0 of    1 processors
+
+     k-point   1:  0.0000 0.0000 0.0000
+
+     G-space vectors for FFT:
+     estimated  FFT memory size for G-space:       0.01 MB
+     estimated  FFT memory size for R-space:       0.01 MB
+     total      FFT memory size:                   0.02 MB
+
+     Ewald energy           =       0.00000000 Ry
+     Hartree energy         =       0.00000000 Ry
+     XC energy              =       0.00000000 Ry
+     local contribution     =       0.00000000 Ry
+     non-local contribution =       0.00000000 Ry
+     total energy           =       0.00000000 Ry
+
+     convergence thresholds:
+     energy error            =   0.0000E+00 Ry
+     scf error               =   0.0000E+00 Ry
+
+     SCF iterations:    1
+     total time          =      0.10s CPU      0.12s WALL
+
+     Writing wavefunctions to ./tmp/
+
+     init_run     :      0.07s CPU      0.08s WALL
+     electrons    :      0.10s CPU      0.12s WALL
+
+     PWSCF        :      0.17s CPU      0.20s WALL
+
+     This run was terminated on: 10:00:01  15Jun2026

--- a/tests/fixtures/logs/scf_failed_to_converge.log
+++ b/tests/fixtures/logs/scf_failed_to_converge.log
@@ -1,0 +1,56 @@
+Program pw.x v.7.2 starts on 15Jun2026 at 10:00:00
+
+     Program PATH: /usr/local/bin/pw.x
+     Hostname: localhost
+
+     Current dimensions of program pw:
+     natx    =      1000
+     ntypx   =        10
+     npwx    =      1000
+     nbnd    =        20
+     npol    =         1
+     npsa    =         1
+
+     bravais-lattice index =    2
+     lattice parameter (alat)  =  10.2600  a.u.
+     unit-cell volume          = 543.0936 (a.u.)^3
+
+     number of atoms/cell =    2
+     number of atomic types    =    1
+     number of Kohn-Sham states =    10
+
+     kinetic-energy cutoff     =   30.0000  Ry
+     charge density cutoff     =  240.0000  Ry
+     convergence threshold     =   1.0E-08
+
+     Electron dynamics: steepest-descent
+
+     Writing output data to ./tmp/
+
+     init_run     :      0.07s CPU      0.08s WALL
+
+     total   pseudopotential    local   ultrasoft(paw)      beta
+     Rcut(pseudopotential) =    2.30  2.30  2.30  2.30  2.30 a.u.
+     Rcut(ultrasoft)       =    2.30  2.30  2.30  2.30  2.30 a.u.
+
+     Ewald energy           =       0.00000000 Ry
+     Hartree energy         =       0.00000000 Ry
+     XC energy              =       0.00000000 Ry
+     local contribution     =       0.00000000 Ry
+     non-local contribution =       0.00000000 Ry
+     total energy           =       0.00000000 Ry
+
+     SCF iterations:   50
+     total time          =      1.00s CPU      1.20s WALL
+
+     WARNING: SCF did not converge after 50 iterations
+     WARNING: Total energy error: 1.2345E-04 Ry
+
+     Writing wavefunctions to ./tmp/
+
+     init_run     :      0.07s CPU      0.08s WALL
+     electrons    :      1.00s CPU      1.20s WALL
+
+     PWSCF        :      1.07s CPU      1.28s WALL
+
+     This run was terminated on: 10:00:02  15Jun2026

--- a/tests/fixtures/valid/relax_valid.in
+++ b/tests/fixtures/valid/relax_valid.in
@@ -1,0 +1,23 @@
+&CONTROL
+  calculation  = "relax"
+/
+&SYSTEM
+  ibrav     = 1,
+  celldm(1) =12.0,
+  nat       = 2,
+  ntyp      = 2,
+  ecutwfc   = 24.D0,
+  ecutrho   = 144.D0,
+/
+&ELECTRONS
+  conv_thr  = 1.0e-7
+/
+&IONS
+/
+ATOMIC_SPECIES
+O  1.00  O.pz-rrkjus.UPF
+C  1.00  C.pz-rrkjus.UPF
+ATOMIC_POSITIONS {bohr}
+C  2.256  0.0  0.0
+O  0.000  0.0  0.0  0 0 0
+K_POINTS {Gamma}

--- a/tests/fixtures/valid/scf_valid.in
+++ b/tests/fixtures/valid/scf_valid.in
@@ -1,0 +1,20 @@
+ &control
+    calculation = 'scf'
+    tstress=.true.
+ /
+ &system
+    ibrav=2, celldm(1) =10.20,
+    nat=2, ntyp=1,
+    ecutwfc=12.0
+ /
+ &electrons
+ /
+ATOMIC_SPECIES
+ Si  28.086  Si.pz-vbc.UPF
+ATOMIC_POSITIONS (alat)
+ Si 0.00 0.00 0.00
+ Si 0.25 0.25 0.25
+K_POINTS
+  2
+   0.250000  0.250000  0.250000   1.00
+   0.250000  0.250000  0.750000   3.00

--- a/tests/fixtures/valid/silicon_scf_valid.in
+++ b/tests/fixtures/valid/silicon_scf_valid.in
@@ -1,0 +1,26 @@
+! Silicon SCF calculation
+&CONTROL
+  calculation = 'scf'
+  restart_mode = 'from_scratch'
+  pseudo_dir = './pseudo/'
+  outdir = './tmp/'
+/
+&SYSTEM
+  ibrav = 2
+  celldm(1) = 10.26
+  nat = 2
+  ntyp = 1
+  ecutwfc = 30.0
+  ecutrho = 240.0
+/
+&ELECTRONS
+  conv_thr = 1.0d-8
+  mixing_beta = 0.7
+/
+ATOMIC_SPECIES
+Si 28.086 Si.pbe-n-rrkjus_psl.1.0.0.UPF
+ATOMIC_POSITIONS {crystal}
+Si 0.00 0.00 0.00
+Si 0.25 0.25 0.25
+K_POINTS {automatic}
+8 8 8 0 0 0

--- a/tests/test_fixture_cli.py
+++ b/tests/test_fixture_cli.py
@@ -1,0 +1,179 @@
+"""Tests for agent CLI against fixtures with stable DiagnosticEnvelope/v1 JSON."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+VALID_DIR = FIXTURES_DIR / "valid"
+INVALID_DIR = FIXTURES_DIR / "invalid"
+LOGS_DIR = FIXTURES_DIR / "logs"
+
+
+def run_tool(args: list[str], timeout: int = 30) -> dict[str, Any]:
+    """Run the qe-lsp-tool and return the JSON output."""
+    cmd = [sys.executable, "-m", "qe_lsp.tool"] + args
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, timeout=timeout, cwd=str(FIXTURES_DIR)
+    )
+    if result.returncode not in (0, 1):  # 0 = ok, 1 = blocking diagnostics
+        pytest.fail(f"Tool failed with code {result.returncode}: {result.stderr}")
+    return cast("dict[str, Any]", json.loads(result.stdout))
+
+
+class TestValidFixtures:
+    """Valid fixtures should have no blocking diagnostics."""
+
+    def test_valid_scf_no_blocking(self) -> None:
+        payload = run_tool(["check", str(VALID_DIR / "scf_valid.in")])
+        assert payload["ok"] is True
+        assert payload["summary"]["blocking"] == 0
+        assert payload["software"] == "qe"
+
+    def test_valid_relax_no_blocking(self) -> None:
+        payload = run_tool(["check", str(VALID_DIR / "relax_valid.in")])
+        assert payload["ok"] is True
+        assert payload["summary"]["blocking"] == 0
+
+    def test_valid_silicon_scf_no_blocking(self) -> None:
+        payload = run_tool(["check", str(VALID_DIR / "silicon_scf_valid.in")])
+        assert payload["ok"] is True
+        assert payload["summary"]["blocking"] == 0
+
+
+class TestInvalidFixtures:
+    """Invalid fixtures should have blocking diagnostics."""
+
+    def test_missing_cell_parameters_blocking(self) -> None:
+        payload = run_tool(["check", str(INVALID_DIR / "missing_cell_parameters.in")])
+        assert payload["ok"] is False
+        assert payload["summary"]["blocking"] > 0
+        assert any(d["code"] == "QE-TE004" for d in payload["diagnostics"])
+
+    def test_low_ecutrho_ratio_warning(self) -> None:
+        payload = run_tool(["check", str(INVALID_DIR / "low_ecutrho_ratio.in")])
+        # This should be a warning, not blocking
+        assert payload["summary"]["warnings"] > 0
+        assert any("4x to 16x" in d["message"] for d in payload["diagnostics"])
+
+    def test_unclosed_namelist_blocking(self) -> None:
+        payload = run_tool(["check", str(INVALID_DIR / "unclosed_namelist.in")])
+        assert payload["ok"] is False
+        assert payload["summary"]["blocking"] > 0
+
+    def test_pseudo_element_mismatch_blocking(self) -> None:
+        payload = run_tool(["check", str(INVALID_DIR / "pseudo_element_mismatch.in")])
+        assert payload["ok"] is False
+        assert payload["summary"]["blocking"] > 0
+
+    def test_atomic_positions_without_species_blocking(self) -> None:
+        payload = run_tool(["check", str(INVALID_DIR / "atomic_positions_without_species.in")])
+        assert payload["ok"] is False
+        assert payload["summary"]["blocking"] > 0
+
+    def test_gamma_nonzero_offset_warning(self) -> None:
+        payload = run_tool(["check", str(INVALID_DIR / "gamma_nonzero_offset.in")])
+        assert payload["summary"]["warnings"] > 0
+
+
+class TestLogFixtures:
+    """Log fixtures should be parseable (logs are not parsed by check)."""
+
+    def test_logs_directory_exists(self) -> None:
+        assert LOGS_DIR.exists()
+        assert len(list(LOGS_DIR.glob("*.log"))) >= 1
+
+
+class TestDiagnosticEnvelopeSchema:
+    """All diagnostics should match DiagnosticEnvelope/v1."""
+
+    def test_envelope_fields_on_valid(self) -> None:
+        payload = run_tool(["check", str(VALID_DIR / "scf_valid.in")])
+        assert "diagnostic_engine" in payload
+        assert "ok" in payload
+        assert "diagnostics" in payload
+        assert "summary" in payload
+        assert "blocking" in payload["summary"]
+        assert "errors" in payload["summary"]
+        assert "warnings" in payload["summary"]
+
+    def test_diagnostic_fields(self) -> None:
+        payload = run_tool(["check", str(INVALID_DIR / "missing_cell_parameters.in")])
+        for diag in payload["diagnostics"]:
+            assert "code" in diag
+            assert "severity" in diag
+            assert "category" in diag
+            assert "confidence" in diag
+            assert "source" in diag
+            assert "range" in diag
+            assert "software" in diag
+            assert "path" in diag
+            assert "message" in diag
+            assert "blocking" in diag
+            assert "diagnostic_engine" in diag
+
+
+class TestAgentCLI:
+    """Test other agent CLI operations."""
+
+    def test_capabilities(self) -> None:
+        payload = run_tool(["capabilities"])
+        assert payload["software"] == "qe"
+        assert "diagnostics" in payload["capabilities"]
+        assert "fix-placeholder" in payload["capabilities"]
+
+    def test_context(self) -> None:
+        payload = run_tool(
+            ["context", str(VALID_DIR / "scf_valid.in"), "--line", "2", "--character", "5"]
+        )
+        assert "context" in payload
+        assert "position" in payload
+
+    def test_complete(self) -> None:
+        payload = run_tool(
+            ["complete", str(VALID_DIR / "scf_valid.in"), "--line", "2", "--character", "5"]
+        )
+        assert "items" in payload
+        assert isinstance(payload["items"], list)
+
+    def test_hover(self) -> None:
+        payload = run_tool(
+            ["hover", str(VALID_DIR / "scf_valid.in"), "--line", "2", "--character", "5"]
+        )
+        assert "contents" in payload or payload.get("status") == "unavailable"
+
+    def test_symbols(self) -> None:
+        payload = run_tool(["symbols", str(VALID_DIR / "scf_valid.in")])
+        assert "items" in payload
+        assert isinstance(payload["items"], list)
+
+    def test_fix(self) -> None:
+        payload = run_tool(
+            [
+                "fix",
+                str(INVALID_DIR / "missing_cell_parameters.in"),
+                "--line",
+                "5",
+                "--character",
+                "5",
+            ]
+        )
+        assert "actions" in payload
+        assert isinstance(payload["actions"], list)
+
+
+class TestPreflightFixtures:
+    """Test preflight fixtures with intent.json."""
+
+    def test_preflight_valid(self) -> None:
+        payload = run_tool(["check", str(FIXTURES_DIR / "preflight" / "valid_pw" / "pw.in")])
+        assert payload["ok"] is True
+
+    def test_preflight_invalid(self) -> None:
+        payload = run_tool(["check", str(FIXTURES_DIR / "preflight" / "ntyp_mismatch" / "pw.in")])
+        # ntyp_mismatch produces a warning about mixed pseudopotential families
+        assert payload["summary"]["warnings"] > 0


### PR DESCRIPTION
## Summary

Adds closed-loop QE input and log fixtures plus agent CLI regression tests for DiagnosticEnvelope/v1-style JSON outputs.

Fixes #92
Refs #90 #91

## Changes

- Added valid QE input fixtures for SCF, relax, and silicon SCF flows.
- Added invalid fixtures for missing CELL_PARAMETERS, low ecutrho ratio, unclosed namelist, pseudo/species mismatch, missing species, and gamma offset warnings.
- Added log fixtures for converged, failed-to-converge, and ecutrho warning cases.
- Added tests/test_fixture_cli.py to exercise check, capabilities, context, completion, hover, symbols, fix, and preflight fixture paths through qe_lsp.tool.

## Test Plan

- python -m py_compile src/qe_lsp/server.py tests/test_basic.py
- python -m pytest -q
- black --check src tests
- ruff check .
- mypy src tests
- pre-commit run --all-files
- python -m build --sdist --wheel

## Evidence

- Full local pytest: 654 passed, 4 existing collection warnings.
- Fixture regression test after formatting/pre-commit: 20 passed.
