### PR TITLE
feat(provenance): add OpenQC v1 traceability report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,8 @@ test:
 
 check: lint typecheck test
 
+traceability:
+	python3 scripts/generate-traceability-report.py
+
 cleanup-merged:
 	bash scripts/cleanup_merged_worktrees.sh

--- a/raw/assets/manifest.json
+++ b/raw/assets/manifest.json
@@ -1,0 +1,157 @@
+{
+  "entries": [
+    {
+      "path": "CHANGELOG.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/CHANGELOG.md",
+      "stable_id": "raw-assets-CHANGELOG-md"
+    },
+    {
+      "path": "DIAGNOSTIC_ENGINE_V1.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/DIAGNOSTIC_ENGINE_V1.md",
+      "stable_id": "raw-assets-DIAGNOSTIC_ENGINE_V1-md"
+    },
+    {
+      "path": "OPENQC_ALIGNMENT.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/OPENQC_ALIGNMENT.md",
+      "stable_id": "raw-assets-OPENQC_ALIGNMENT-md"
+    },
+    {
+      "path": "README.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/README.md",
+      "stable_id": "raw-assets-README-md"
+    },
+    {
+      "path": "agent-verification-loop.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/agent-verification-loop.md",
+      "stable_id": "raw-assets-agent-verification-loop-md"
+    },
+    {
+      "path": "aluminum_relax.in",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/aluminum_relax.in",
+      "stable_id": "raw-assets-aluminum_relax-in"
+    },
+    {
+      "path": "constants.py",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/constants.py",
+      "stable_id": "raw-assets-constants-py"
+    },
+    {
+      "path": "constants_extract.py",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/constants_extract.py",
+      "stable_id": "raw-assets-constants_extract-py"
+    },
+    {
+      "path": "docs.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/docs.md",
+      "stable_id": "raw-assets-docs-md"
+    },
+    {
+      "path": "example-carbonyl-relax.in",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/example-carbonyl-relax.in",
+      "stable_id": "raw-assets-example-carbonyl-relax-in"
+    },
+    {
+      "path": "fe_spin.in",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/fe_spin.in",
+      "stable_id": "raw-assets-fe_spin-in"
+    },
+    {
+      "path": "parser.py",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/parser.py",
+      "stable_id": "raw-assets-parser-py"
+    },
+    {
+      "path": "parser_extract.py",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/parser_extract.py",
+      "stable_id": "raw-assets-parser_extract-py"
+    },
+    {
+      "path": "pr-review-workflow.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/pr-review-workflow.md",
+      "stable_id": "raw-assets-pr-review-workflow-md"
+    },
+    {
+      "path": "qe-examples.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/qe-examples.md",
+      "stable_id": "raw-assets-qe-examples-md"
+    },
+    {
+      "path": "qe-output-format.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/qe-output-format.md",
+      "stable_id": "raw-assets-qe-output-format-md"
+    },
+    {
+      "path": "qe-programs-reference.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/qe-programs-reference.md",
+      "stable_id": "raw-assets-qe-programs-reference-md"
+    },
+    {
+      "path": "qe-pseudopotentials.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/qe-pseudopotentials.md",
+      "stable_id": "raw-assets-qe-pseudopotentials-md"
+    },
+    {
+      "path": "qe-pw-input-reference.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/qe-pw-input-reference.md",
+      "stable_id": "raw-assets-qe-pw-input-reference-md"
+    },
+    {
+      "path": "silicon_bands.in",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/silicon_bands.in",
+      "stable_id": "raw-assets-silicon_bands-in"
+    },
+    {
+      "path": "silicon_scf.in",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/silicon_scf.in",
+      "stable_id": "raw-assets-silicon_scf-in"
+    },
+    {
+      "path": "sio2_vc_relax.in",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/sio2_vc_relax.in",
+      "stable_id": "raw-assets-sio2_vc_relax-in"
+    },
+    {
+      "path": "upstream-qe-reference.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/upstream-qe-reference.md",
+      "stable_id": "raw-assets-upstream-qe-reference-md"
+    },
+    {
+      "path": "validation.py",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/validation.py",
+      "stable_id": "raw-assets-validation-py"
+    },
+    {
+      "path": "validation_extract.py",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/validation_extract.py",
+      "stable_id": "raw-assets-validation_extract-py"
+    }
+  ],
+  "manifest_version": "1.0.0",
+  "repository": "newtontech/qe-lsp",
+  "schema_version": "provenance-manifest-v1"
+}

--- a/reports/docstring-wiki-raw-traceability.json
+++ b/reports/docstring-wiki-raw-traceability.json
@@ -1,0 +1,864 @@
+{
+  "docstrings": [
+    {
+      "path": "src/qe_lsp/constants.py",
+      "symbol": "constants",
+      "wikiPath": "wiki/entities/quantum-espresso-namelist.md"
+    },
+    {
+      "path": "src/qe_lsp/constants.py",
+      "symbol": "constants",
+      "wikiPath": "wiki/entities/card.md"
+    },
+    {
+      "path": "src/qe_lsp/constants.py",
+      "symbol": "constants",
+      "wikiPath": "wiki/synthesis/control-namelist-reference.md"
+    },
+    {
+      "path": "src/qe_lsp/features/code_actions.py",
+      "symbol": "CodeActionProvider",
+      "wikiPath": "wiki/entities/card.md"
+    },
+    {
+      "path": "src/qe_lsp/features/code_actions.py",
+      "symbol": "CodeActionProvider",
+      "wikiPath": "wiki/entities/atomic-positions-card.md"
+    },
+    {
+      "path": "src/qe_lsp/features/lint.py",
+      "symbol": "LintProvider",
+      "wikiPath": "wiki/synthesis/control-namelist-reference.md"
+    },
+    {
+      "path": "src/qe_lsp/features/lint.py",
+      "symbol": "LintProvider",
+      "wikiPath": "wiki/synthesis/system-namelist-reference.md"
+    },
+    {
+      "path": "src/qe_lsp/features/lint.py",
+      "symbol": "LintProvider",
+      "wikiPath": "wiki/synthesis/electrons-namelist-reference.md"
+    },
+    {
+      "path": "src/qe_lsp/features/lint.py",
+      "symbol": "LintProvider",
+      "wikiPath": "wiki/entities/ecutwfc-ecutrho.md"
+    },
+    {
+      "path": "src/qe_lsp/parser.py",
+      "symbol": "Parameter",
+      "wikiPath": "wiki/entities/quantum-espresso-namelist.md"
+    },
+    {
+      "path": "src/qe_lsp/parser.py",
+      "symbol": "Parameter",
+      "wikiPath": "wiki/entities/card.md"
+    },
+    {
+      "path": "src/qe_lsp/parser.py",
+      "symbol": "Parameter",
+      "wikiPath": "wiki/entities/parameter-assignment.md"
+    },
+    {
+      "path": "src/qe_lsp/rich_diagnostics.py",
+      "symbol": "severity_label",
+      "wikiPath": "wiki/concepts/diagnostic-engine.md"
+    },
+    {
+      "path": "src/qe_lsp/rich_diagnostics.py",
+      "symbol": "severity_label",
+      "wikiPath": "wiki/concepts/diagnostic-engine-v1.md"
+    },
+    {
+      "path": "src/qe_lsp/server.py",
+      "symbol": "_load_language_server",
+      "wikiPath": "wiki/concepts/lsp-server-architecture.md"
+    },
+    {
+      "path": "src/qe_lsp/server.py",
+      "symbol": "_load_language_server",
+      "wikiPath": "wiki/synthesis/openqc-agent-context.md"
+    },
+    {
+      "path": "src/qe_lsp/tool.py",
+      "symbol": "_capabilities_payload",
+      "wikiPath": "wiki/synthesis/openqc-agent-context.md"
+    },
+    {
+      "path": "src/qe_lsp/tool.py",
+      "symbol": "_capabilities_payload",
+      "wikiPath": "wiki/concepts/lsp-server-architecture.md"
+    },
+    {
+      "path": "src/qe_lsp/validation.py",
+      "symbol": "_range_for",
+      "wikiPath": "wiki/concepts/diagnostic-engine.md"
+    },
+    {
+      "path": "src/qe_lsp/validation.py",
+      "symbol": "_range_for",
+      "wikiPath": "wiki/concepts/diagnostic-severity.md"
+    },
+    {
+      "path": "src/qe_lsp/validation.py",
+      "symbol": "_range_for",
+      "wikiPath": "wiki/entities/pseudopotential.md"
+    }
+  ],
+  "generatedAt": "2026-06-15T20:22:19.226273+00:00",
+  "languageId": "qe",
+  "rawManifest": {
+    "ok": true,
+    "path": "raw/assets/manifest.json"
+  },
+  "repository": "https://github.com/newtontech/qe-lsp.git",
+  "ruleIds": [
+    {
+      "code": "QE-INPUT-ERROR-001",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-002",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-003",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-004",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-005",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-006",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-007",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-008",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-009",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-013",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-014",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-015",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-016",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-017",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-018",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-019",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-020",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-001",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-002",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-003",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-004",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-010",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-011",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-012",
+      "sourcePath": "src/qe_lsp/features/agent_api.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-001",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-002",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-003",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-004",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-005",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-006",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-007",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-008",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-009",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-013",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-001",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-002",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-003",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-004",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-010",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-011",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-WARNING-012",
+      "sourcePath": "src/qe_lsp/features/lint.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-014",
+      "sourcePath": "src/qe_lsp/features/test_runner.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-015",
+      "sourcePath": "src/qe_lsp/features/test_runner.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-016",
+      "sourcePath": "src/qe_lsp/features/test_runner.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-017",
+      "sourcePath": "src/qe_lsp/features/test_runner.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-018",
+      "sourcePath": "src/qe_lsp/features/test_runner.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-019",
+      "sourcePath": "src/qe_lsp/features/test_runner.py"
+    },
+    {
+      "code": "QE-INPUT-ERROR-020",
+      "sourcePath": "src/qe_lsp/features/test_runner.py"
+    }
+  ],
+  "schemaVersion": "openqc.lsp.traceability.v1",
+  "serverId": "qe-lsp",
+  "sourceUrls": [
+    {
+      "rawPath": "lsp-capabilities.json",
+      "url": "https://www.quantum-espresso.org/documentation/input-data-description/"
+    },
+    {
+      "rawPath": "lsp-capabilities.json",
+      "url": "https://www.quantum-espresso.org/Doc/INPUT_PW.html"
+    },
+    {
+      "rawPath": "lsp-capabilities.json",
+      "url": "https://www.quantum-espresso.org/Doc/INPUT_PH.html"
+    },
+    {
+      "rawPath": "lsp-capabilities.json",
+      "url": "https://pranabdas.github.io/espresso/hands-on/dos/"
+    },
+    {
+      "rawPath": "lsp-capabilities.json",
+      "url": "https://www.quantum-espresso.org/pseudopotentials/"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://blog.levilentz.com/parse-quantum-espresso-output-file/"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://github.com/QEF/q-e"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://github.com/QEF/q-e/tree/develop/test-suite"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://pranabdas.github.io/espresso/hands-on/dos/"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://wiki.max-centre.eu/index.php/Non_self-consistent_calculations"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://www.materialscloud.org/discover/sssp"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://www.quantum-espresso.org/Doc/INPUT_CP.html"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://www.quantum-espresso.org/Doc/INPUT_PH.html"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://www.quantum-espresso.org/Doc/INPUT_PP.html"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://www.quantum-espresso.org/Doc/INPUT_PROJWFC.html"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://www.quantum-espresso.org/Doc/INPUT_PW.html"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://www.quantum-espresso.org/documentation/"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://www.quantum-espresso.org/documentation/input-data-description/"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://www.quantum-espresso.org/download/"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://www.quantum-espresso.org/pseudopotentials/"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://www.quantum-espresso.org/pseudopotentials/ps-library"
+    },
+    {
+      "rawPath": "raw/assets/CHANGELOG.md",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/CHANGELOG.md"
+    },
+    {
+      "rawPath": "raw/assets/DIAGNOSTIC_ENGINE_V1.md",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/DIAGNOSTIC_ENGINE_V1.md"
+    },
+    {
+      "rawPath": "raw/assets/OPENQC_ALIGNMENT.md",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/OPENQC_ALIGNMENT.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/README.md"
+    },
+    {
+      "rawPath": "raw/assets/agent-verification-loop.md",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/agent-verification-loop.md"
+    },
+    {
+      "rawPath": "raw/assets/aluminum_relax.in",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/aluminum_relax.in"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/constants.py"
+    },
+    {
+      "rawPath": "raw/assets/constants_extract.py",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/constants_extract.py"
+    },
+    {
+      "rawPath": "raw/assets/docs.md",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/docs.md"
+    },
+    {
+      "rawPath": "raw/assets/example-carbonyl-relax.in",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/example-carbonyl-relax.in"
+    },
+    {
+      "rawPath": "raw/assets/fe_spin.in",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/fe_spin.in"
+    },
+    {
+      "rawPath": "raw/assets/manifest.json",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/manifest.json"
+    },
+    {
+      "rawPath": "raw/assets/parser.py",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/parser.py"
+    },
+    {
+      "rawPath": "raw/assets/parser_extract.py",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/parser_extract.py"
+    },
+    {
+      "rawPath": "raw/assets/pr-review-workflow.md",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/pr-review-workflow.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-examples.md",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/qe-examples.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-output-format.md",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/qe-output-format.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-programs-reference.md",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/qe-programs-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-pseudopotentials.md",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/qe-pseudopotentials.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-pw-input-reference.md",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/qe-pw-input-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/silicon_bands.in",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/silicon_bands.in"
+    },
+    {
+      "rawPath": "raw/assets/silicon_scf.in",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/silicon_scf.in"
+    },
+    {
+      "rawPath": "raw/assets/sio2_vc_relax.in",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/sio2_vc_relax.in"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/upstream-qe-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/validation.py"
+    },
+    {
+      "rawPath": "raw/assets/validation_extract.py",
+      "url": "https://github.com/newtontech/qe-lsp/blob/main/raw/assets/validation_extract.py"
+    }
+  ],
+  "summary": {
+    "brokenWikiLinks": 0,
+    "docstringsLinked": 21,
+    "docstringsTotal": 21,
+    "rawManifestFailures": 0,
+    "ruleIdsTotal": 48,
+    "sourceUrlsTotal": 47,
+    "wikiSourcesTotal": 70,
+    "wikiSourcesWithoutRaw": 0
+  },
+  "wikiSources": [
+    {
+      "rawPath": "raw/assets/qe-examples.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/band-structure-dos-workflow.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-programs-reference.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/band-structure-dos-workflow.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/bravais-lattice.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/bravais-lattice.md"
+    },
+    {
+      "rawPath": "raw/assets/DIAGNOSTIC_ENGINE_V1.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/diagnostic-engine.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/diagnostic-engine.md"
+    },
+    {
+      "rawPath": "raw/assets/DIAGNOSTIC_ENGINE_V1.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/diagnostic-severity.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/diagnostic-severity.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/lsp-server-architecture.md"
+    },
+    {
+      "rawPath": "raw/assets/docs.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/lsp-server-architecture.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-examples.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/phonon-calculation.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-programs-reference.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/phonon-calculation.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-output-format.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/qe-output-parsing.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/scf-convergence.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/concepts/scf-convergence.md"
+    },
+    {
+      "rawPath": "raw/assets/silicon_scf.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/atomic-positions-card.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/atomic-positions-card.md"
+    },
+    {
+      "rawPath": "raw/assets/parser.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/atomic-species-card.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/atomic-species-card.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/calculation-type.md"
+    },
+    {
+      "rawPath": "raw/assets/silicon_scf.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/calculation-type.md"
+    },
+    {
+      "rawPath": "raw/assets/sio2_vc_relax.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/calculation-type.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/card.md"
+    },
+    {
+      "rawPath": "raw/assets/parser.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/card.md"
+    },
+    {
+      "rawPath": "raw/assets/sio2_vc_relax.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/cell-parameters-card.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/cell-parameters-card.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/celldm-parameter.md"
+    },
+    {
+      "rawPath": "raw/assets/silicon_scf.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/celldm-parameter.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/ecutwfc-ecutrho.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/ecutwfc-ecutrho.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/ibrav-parameter.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/ibrav-parameter.md"
+    },
+    {
+      "rawPath": "raw/assets/silicon_scf.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/k-points.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/k-points.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/mixing-beta.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/mixing-beta.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/parameter-assignment.md"
+    },
+    {
+      "rawPath": "raw/assets/parser.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/parameter-assignment.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-examples.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/ph-x-phonon.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-programs-reference.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/ph-x-phonon.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-examples.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/post-processing-programs.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-programs-reference.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/post-processing-programs.md"
+    },
+    {
+      "rawPath": "raw/assets/parser.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/pseudopotential.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/pseudopotential.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/quantum-espresso-namelist.md"
+    },
+    {
+      "rawPath": "raw/assets/parser.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/entities/quantum-espresso-namelist.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/cell-namelist-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/control-namelist-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/electrons-namelist-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/aluminum_relax.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/examples-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/fe_spin.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/examples-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-examples.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/examples-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/silicon_bands.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/examples-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/silicon_scf.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/examples-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/sio2_vc_relax.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/examples-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/parser.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/input-file-format.md"
+    },
+    {
+      "rawPath": "raw/assets/silicon_scf.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/input-file-format.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/ions-namelist-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/DIAGNOSTIC_ENGINE_V1.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/openqc-agent-context.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/openqc-agent-context.md"
+    },
+    {
+      "rawPath": "raw/assets/example-carbonyl-relax.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/openqc-agent-context.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-examples.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/openqc-agent-context.md"
+    },
+    {
+      "rawPath": "raw/assets/silicon_scf.in",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/openqc-agent-context.md"
+    },
+    {
+      "rawPath": "raw/assets/upstream-qe-reference.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/openqc-agent-context.md"
+    },
+    {
+      "rawPath": "raw/assets/validation.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/openqc-agent-context.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-programs-reference.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/programs-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/qe-pseudopotentials.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/pseudopotential-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/quick-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/quick-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/constants.py",
+      "sourceUrl": "",
+      "wikiPath": "wiki/synthesis/system-namelist-reference.md"
+    }
+  ]
+}

--- a/scripts/generate-traceability-report.py
+++ b/scripts/generate-traceability-report.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""OpenQC v1 traceability report generator.
+
+Generates reports/docstring-wiki-raw-traceability.json satisfying the
+openqc.lsp.traceability.v1 schema.  Scans the source tree for:
+
+  - docstrings that reference wiki paths (via "See also:" or other patterns)
+  - wiki pages that reference raw asset files
+  - rule identifiers defined in source code
+  - upstream source URLs from the raw manifest
+  - raw asset file existence / validity
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REPORTS_DIR = REPO_ROOT / "reports"
+REPORT_PATH = REPORTS_DIR / "docstring-wiki-raw-traceability.json"
+
+# repo identity
+SERVER_ID = "qe-lsp"
+LANGUAGE_ID = "qe"
+REPOSITORY = "newtontech/qe-lsp"
+
+# ---------------------------------------------------------------------------
+# Regex patterns
+# ---------------------------------------------------------------------------
+
+#: Pattern for "See also:" wiki references in docstrings
+SEE_ALSO_RE = re.compile(
+    r"See also:\s*(.+)",
+    re.IGNORECASE,
+)
+
+#: Extract a clean wiki path from a "See also:" line
+SEE_ALSO_WIKI_RE = re.compile(r"wiki/(?:entities|concepts|synthesis)/[\w/\-]+\.md")
+
+#: Pattern for raw asset references in wiki pages
+RAW_ASSET_RE = re.compile(r"raw/assets/[\w./-]+")
+
+#: Pattern for rule code references (e.g. QE-E001, QE-W012)
+RULE_CODE_RE = re.compile(r"QE-[EWI]\d{3}")
+
+#: Pattern for source URLs in markdown tables/lists
+SOURCE_URL_RE = re.compile(
+    r"https?://(?:www\.)?(?:quantum-espresso|pranabdas|github|materialscloud|blog\.levilentz|wiki\.max-centre)"
+    r"\.[\w./?=&%-]+",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def repo_relative(path: Path) -> str:
+    """Return path relative to REPO_ROOT."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _infer_symbol(text: str, pyfile: Path) -> str:
+    """Infer a module/class/function name from the file."""
+    cm = re.search(r"^class\s+(\w+)", text, re.MULTILINE)
+    if cm:
+        return cm.group(1)
+    fm = re.search(r"^def\s+(\w+)", text, re.MULTILINE)
+    if fm:
+        return fm.group(1)
+    return pyfile.stem
+
+
+def _find_source_url(text: str, raw_path: str) -> str | None:
+    """Search for a URL near a raw path reference."""
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if raw_path in line:
+            for j in range(i, min(i + 4, len(lines))):
+                urls = SOURCE_URL_RE.findall(lines[j])
+                if urls:
+                    return str(urls[0])
+    return None
+
+
+def _git_remote_url() -> str:
+    """Get the git remote origin URL."""
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return ""
+
+
+def _openqc_rule_code(code: str) -> str:
+    """Convert legacy QE-E001/QE-W001/QE-I001 codes to OpenQC rule IDs."""
+    match = re.fullmatch(r"QE-([EWI])(\d{3})", code)
+    if not match:
+        return code
+    category = {
+        "E": "ERROR",
+        "W": "WARNING",
+        "I": "INFO",
+    }[match.group(1)]
+    return f"QE-INPUT-{category}-{match.group(2)}"
+
+
+def _raw_asset_files() -> list[Path]:
+    """Return all raw asset files tracked by the traceability manifest."""
+    raw_assets = REPO_ROOT / "raw" / "assets"
+    if not raw_assets.exists():
+        return []
+    return sorted(path for path in raw_assets.rglob("*") if path.is_file())
+
+
+def write_raw_asset_manifest() -> Path:
+    """Write a deterministic manifest for all raw evidence assets."""
+    manifest_path = REPO_ROOT / "raw" / "assets" / "manifest.json"
+    entries = []
+    for raw_file in _raw_asset_files():
+        if raw_file == manifest_path:
+            continue
+        raw_rel = repo_relative(raw_file)
+        entries.append(
+            {
+                "path": raw_rel.removeprefix("raw/assets/"),
+                "source_type": "raw_asset",
+                "source_url": f"https://github.com/{REPOSITORY}/blob/main/{raw_rel}",
+                "stable_id": raw_rel.replace("/", "-").replace(".", "-"),
+            }
+        )
+    payload = {
+        "manifest_version": "1.0.0",
+        "schema_version": "provenance-manifest-v1",
+        "repository": REPOSITORY,
+        "entries": entries,
+    }
+    manifest_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+# ---------------------------------------------------------------------------
+# Collectors
+# ---------------------------------------------------------------------------
+
+
+def collect_docstrings() -> list[dict[str, str]]:
+    """Scan source code for docstrings referencing wiki paths."""
+    entries: list[dict[str, str]] = []
+    src_dir = REPO_ROOT / "src"
+    for pyfile in sorted(src_dir.rglob("*.py")):
+        text = pyfile.read_text(encoding="utf-8")
+        # Find "See also:" lines in docstring context
+        see_also_matches = SEE_ALSO_RE.findall(text)
+        if not see_also_matches:
+            continue
+        symbol = _infer_symbol(text, pyfile)
+        for match in see_also_matches:
+            wiki_paths = SEE_ALSO_WIKI_RE.findall(match)
+            for wp in wiki_paths:
+                entries.append(
+                    {
+                        "path": repo_relative(pyfile),
+                        "wikiPath": wp,
+                        "symbol": symbol,
+                    }
+                )
+    # Deduplicate
+    seen: set[tuple[str, str, str]] = set()
+    unique: list[dict[str, str]] = []
+    for e in entries:
+        key = (e["path"], e["wikiPath"], e["symbol"])
+        if key not in seen:
+            seen.add(key)
+            unique.append(e)
+    return unique
+
+
+def collect_wiki_sources() -> list[dict[str, str]]:
+    """Scan wiki pages for references to raw assets and source URLs."""
+    entries: list[dict[str, str]] = []
+    wiki_dir = REPO_ROOT / "wiki"
+    for mdfile in sorted(wiki_dir.rglob("*.md")):
+        text = mdfile.read_text(encoding="utf-8")
+        raw_refs = RAW_ASSET_RE.findall(text)
+        if not raw_refs:
+            continue
+        for raw_path in sorted(set(raw_refs)):
+            source_url = _find_source_url(text, raw_path)
+            entries.append(
+                {
+                    "wikiPath": repo_relative(mdfile),
+                    "rawPath": raw_path,
+                    "sourceUrl": source_url or "",
+                }
+            )
+    return entries
+
+
+def collect_rule_ids() -> list[dict[str, str]]:
+    """Extract rule identifiers from lint and diagnostic source."""
+    entries: list[dict[str, str]] = []
+    src_dir = REPO_ROOT / "src"
+    for pyfile in sorted(src_dir.rglob("*.py")):
+        text = pyfile.read_text(encoding="utf-8")
+        codes = RULE_CODE_RE.findall(text)
+        if not codes:
+            continue
+        for code in sorted(set(codes)):
+            entries.append(
+                {
+                    "code": _openqc_rule_code(code),
+                    "sourcePath": repo_relative(pyfile),
+                }
+            )
+    return entries
+
+
+def collect_source_urls() -> list[dict[str, str]]:
+    """Collect upstream source URLs from raw assets."""
+    entries: list[dict[str, str]] = []
+
+    # 1. From lsp-capabilities.json sourceProvenance
+    cap_path = REPO_ROOT / "lsp-capabilities.json"
+    if cap_path.exists():
+        try:
+            cap = json.loads(cap_path.read_text(encoding="utf-8"))
+            for prov in cap.get("sourceProvenance", []):
+                url = prov.get("url", "")
+                raw_path = prov.get("path", "")
+                if url:
+                    entries.append({"rawPath": raw_path or "lsp-capabilities.json", "url": url})
+        except (OSError, ValueError):
+            pass
+
+    # 2. From upstream-qe-reference.md
+    upstream_path = REPO_ROOT / "raw" / "assets" / "upstream-qe-reference.md"
+    if upstream_path.exists():
+        text = upstream_path.read_text(encoding="utf-8")
+        urls = SOURCE_URL_RE.findall(text)
+        for url in sorted(set(urls)):
+            entries.append(
+                {
+                    "rawPath": repo_relative(upstream_path),
+                    "url": url,
+                }
+            )
+
+    # 3. Stable GitHub links for every raw evidence asset, including the manifest.
+    for raw_file in _raw_asset_files():
+        raw_rel = repo_relative(raw_file)
+        entries.append(
+            {
+                "rawPath": raw_rel,
+                "url": f"https://github.com/{REPOSITORY}/blob/main/{raw_rel}",
+            }
+        )
+
+    # Deduplicate
+    seen: set[tuple[str, str]] = set()
+    unique: list[dict[str, str]] = []
+    for e in entries:
+        key = (e["rawPath"], e["url"])
+        if key not in seen:
+            seen.add(key)
+            unique.append(e)
+    return unique
+
+
+def collect_raw_manifest() -> dict[str, object]:
+    """Check the raw/assets manifest descriptor."""
+    manifest_path = REPO_ROOT / "raw" / "assets" / "manifest.json"
+    return {
+        "path": repo_relative(manifest_path),
+        "ok": manifest_path.is_file() and manifest_path.stat().st_size > 0,
+    }
+
+
+def build_summary(
+    docstrings: list[dict[str, str]],
+    wiki_sources: list[dict[str, str]],
+    rule_ids: list[dict[str, str]],
+    source_urls: list[dict[str, str]],
+    raw_manifest: dict[str, object],
+) -> dict[str, Any]:
+    """Build the summary section."""
+    docstrings_linked = sum(
+        1
+        for item in docstrings
+        if (REPO_ROOT / item["path"]).exists() and (REPO_ROOT / item["wikiPath"]).exists()
+    )
+    broken_wiki_links = sum(1 for item in docstrings if not (REPO_ROOT / item["wikiPath"]).exists())
+    wiki_sources_without_raw = sum(
+        1 for item in wiki_sources if not (REPO_ROOT / item["rawPath"]).exists()
+    )
+    return {
+        "docstringsTotal": len(docstrings),
+        "docstringsLinked": docstrings_linked,
+        "brokenWikiLinks": broken_wiki_links,
+        "wikiSourcesWithoutRaw": wiki_sources_without_raw,
+        "rawManifestFailures": 0 if raw_manifest["ok"] else 1,
+        "ruleIdsTotal": len(rule_ids),
+        "sourceUrlsTotal": len(source_urls),
+        "wikiSourcesTotal": len(wiki_sources),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+
+def generate_report() -> dict[str, Any]:
+    """Generate the full OpenQC v1 traceability report."""
+    write_raw_asset_manifest()
+    docstrings = collect_docstrings()
+    wiki_sources = collect_wiki_sources()
+    rule_ids = collect_rule_ids()
+    source_urls = collect_source_urls()
+    raw_manifest = collect_raw_manifest()
+    summary = build_summary(docstrings, wiki_sources, rule_ids, source_urls, raw_manifest)
+
+    git_url = _git_remote_url()
+
+    report: dict[str, Any] = {
+        "schemaVersion": "openqc.lsp.traceability.v1",
+        "serverId": SERVER_ID,
+        "repository": git_url or f"https://github.com/{REPOSITORY}",
+        "languageId": LANGUAGE_ID,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "summary": summary,
+        "docstrings": docstrings,
+        "wikiSources": wiki_sources,
+        "ruleIds": rule_ids,
+        "sourceUrls": source_urls,
+        "rawManifest": raw_manifest,
+    }
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Generate the report and write it to disk."""
+    report = generate_report()
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(
+        json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Report written to {REPORT_PATH}")
+    print(f"  schemaVersion: {report['schemaVersion']}")
+    print(f"  serverId: {report['serverId']}")
+    print(f"  docstrings: {len(report['docstrings'])} entries")
+    print(f"  wikiSources: {len(report['wikiSources'])} entries")
+    print(f"  ruleIds: {len(report['ruleIds'])} entries")
+    print(f"  sourceUrls: {len(report['sourceUrls'])} entries")
+    print(f"  rawManifest: {len(report['rawManifest'])} entries")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/qe_lsp/constants.py
+++ b/src/qe_lsp/constants.py
@@ -1,4 +1,8 @@
-"""Shared constants for qe-lsp."""
+"""
+Shared constants for qe-lsp.
+
+See also: wiki/entities/quantum-espresso-namelist.md, wiki/entities/card.md, wiki/synthesis/control-namelist-reference.md
+"""
 
 SERVER_NAME = "qe-lsp"
 

--- a/src/qe_lsp/features/code_actions.py
+++ b/src/qe_lsp/features/code_actions.py
@@ -1,5 +1,7 @@
 """Code actions provider for Quantum ESPRESSO input files.
 
+See also: wiki/entities/card.md, wiki/entities/atomic-positions-card.md
+
 Provides quick fixes for common QE input errors: unclosed namelists, unknown
 keywords (with typo correction), invalid enum values, casing fixes, missing
 required namelists, and deprecated keyword replacements.  Each code action

--- a/src/qe_lsp/features/lint.py
+++ b/src/qe_lsp/features/lint.py
@@ -1,5 +1,7 @@
 """Schema-aware static lint rules for Quantum ESPRESSO input files.
 
+See also: wiki/synthesis/control-namelist-reference.md, wiki/synthesis/system-namelist-reference.md, wiki/synthesis/electrons-namelist-reference.md, wiki/entities/ecutwfc-ecutrho.md
+
 Produces LSP diagnostics with stable rule codes so that automated coding
 agents and CI pipelines can filter and act on specific categories of
 findings.  All checks are deterministic, offline, and based on the

--- a/src/qe_lsp/parser.py
+++ b/src/qe_lsp/parser.py
@@ -1,4 +1,8 @@
-"""Small Quantum ESPRESSO input parser for validation."""
+"""
+Small Quantum ESPRESSO input parser for validation.
+
+See also: wiki/entities/quantum-espresso-namelist.md, wiki/entities/card.md, wiki/entities/parameter-assignment.md
+"""
 
 from dataclasses import dataclass, field
 import re

--- a/src/qe_lsp/rich_diagnostics.py
+++ b/src/qe_lsp/rich_diagnostics.py
@@ -1,5 +1,7 @@
 """Diagnostic Engine v1 serialization helpers.
 
+See also: wiki/concepts/diagnostic-engine.md, wiki/concepts/diagnostic-engine-v1.md
+
 The module keeps existing LSP/provider diagnostics untouched and provides a
 python-lsp-server-style provider boundary for agent-facing JSON consumers.
 """

--- a/src/qe_lsp/server.py
+++ b/src/qe_lsp/server.py
@@ -1,4 +1,8 @@
-"""qe Language Server Protocol server wiring."""
+"""
+qe Language Server Protocol server wiring.
+
+See also: wiki/concepts/lsp-server-architecture.md, wiki/synthesis/openqc-agent-context.md
+"""
 
 from importlib import import_module
 from typing import Any, Type, cast

--- a/src/qe_lsp/tool.py
+++ b/src/qe_lsp/tool.py
@@ -1,4 +1,8 @@
-"""Agent-facing CLI for Diagnostic Engine v1 operations."""
+"""
+Agent-facing CLI for Diagnostic Engine v1 operations.
+
+See also: wiki/synthesis/openqc-agent-context.md, wiki/concepts/lsp-server-architecture.md
+"""
 
 from __future__ import annotations
 

--- a/src/qe_lsp/validation.py
+++ b/src/qe_lsp/validation.py
@@ -1,4 +1,8 @@
-"""Quantum ESPRESSO validation checks that produce LSP diagnostics."""
+"""
+Quantum ESPRESSO validation checks that produce LSP diagnostics.
+
+See also: wiki/concepts/diagnostic-engine.md, wiki/concepts/diagnostic-severity.md, wiki/entities/pseudopotential.md
+"""
 
 from typing import List
 

--- a/tests/test_openqc_traceability.py
+++ b/tests/test_openqc_traceability.py
@@ -1,0 +1,328 @@
+"""Focused tests for the OpenQC v1 docstring-wiki-raw traceability report contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REPORT_PATH = REPO_ROOT / "reports" / "docstring-wiki-raw-traceability.json"
+CHECKER_SCRIPT = REPO_ROOT / "scripts" / "generate-traceability-report.py"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def report() -> dict:
+    """Load the generated traceability report."""
+    if not REPORT_PATH.exists():
+        pytest.skip(
+            f"Report not found at {REPORT_PATH}; run scripts/generate-traceability-report.py first"
+        )
+    with open(REPORT_PATH, encoding="utf-8") as f:
+        return cast(dict[str, Any], json.load(f))
+
+
+# ---------------------------------------------------------------------------
+# Schema contract tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenQCTraceabilityV1Schema:
+    """Verify the report satisfies the openqc.lsp.traceability.v1 contract."""
+
+    def test_schema_version(self, report: dict) -> None:
+        assert report["schemaVersion"] == "openqc.lsp.traceability.v1"
+
+    def test_top_level_fields_present(self, report: dict) -> None:
+        required = [
+            "schemaVersion",
+            "serverId",
+            "repository",
+            "languageId",
+            "generatedAt",
+            "summary",
+            "docstrings",
+            "wikiSources",
+            "ruleIds",
+            "sourceUrls",
+            "rawManifest",
+        ]
+        for field in required:
+            assert field in report, f"Missing required top-level field: {field}"
+
+    def test_server_id(self, report: dict) -> None:
+        assert isinstance(report["serverId"], str)
+        assert len(report["serverId"]) > 0
+
+    def test_repository(self, report: dict) -> None:
+        assert isinstance(report["repository"], str)
+        assert "qe-lsp" in report["repository"]
+
+    def test_language_id(self, report: dict) -> None:
+        assert report["languageId"] == "qe"
+
+    def test_generated_at_format(self, report: dict) -> None:
+        from datetime import datetime
+
+        dt = datetime.fromisoformat(report["generatedAt"])
+        assert dt.tzinfo is not None  # must be timezone-aware
+
+    def test_summary_structure(self, report: dict) -> None:
+        s = report["summary"]
+        assert "docstringsTotal" in s
+        assert "docstringsLinked" in s
+        assert "brokenWikiLinks" in s
+        assert "wikiSourcesWithoutRaw" in s
+        assert "rawManifestFailures" in s
+        assert s["docstringsLinked"] == s["docstringsTotal"]
+        assert s["brokenWikiLinks"] == 0
+        assert s["wikiSourcesWithoutRaw"] == 0
+        assert s["rawManifestFailures"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Docstrings contract
+# ---------------------------------------------------------------------------
+
+
+class TestDocstrings:
+    """Verify docstrings[] entries."""
+
+    def test_docstrings_is_list(self, report: dict) -> None:
+        assert isinstance(report["docstrings"], list)
+        assert len(report["docstrings"]) > 0
+
+    def test_docstring_entry_fields(self, report: dict) -> None:
+        for entry in report["docstrings"]:
+            assert isinstance(entry, dict)
+            assert "path" in entry
+            assert "wikiPath" in entry
+            assert "symbol" in entry
+            # All must be non-empty strings
+            assert isinstance(entry["path"], str) and len(entry["path"]) > 0
+            assert isinstance(entry["wikiPath"], str) and len(entry["wikiPath"]) > 0
+            assert isinstance(entry["symbol"], str) and len(entry["symbol"]) > 0
+            # wikiPath must start with wiki/
+            assert entry["wikiPath"].startswith("wiki/")
+            # path must be a repo-relative path
+            assert not entry["path"].startswith("/")
+
+    def test_docstring_paths_exist(self, report: dict) -> None:
+        for entry in report["docstrings"]:
+            full_path = REPO_ROOT / entry["path"]
+            assert full_path.exists(), f"Source file not found: {entry['path']}"
+
+    def test_docstring_wiki_paths_exist(self, report: dict) -> None:
+        for entry in report["docstrings"]:
+            full_path = REPO_ROOT / entry["wikiPath"]
+            assert full_path.exists(), f"Wiki page not found: {entry['wikiPath']}"
+
+
+# ---------------------------------------------------------------------------
+# Wiki sources contract
+# ---------------------------------------------------------------------------
+
+
+class TestWikiSources:
+    """Verify wikiSources[] entries."""
+
+    def test_wiki_sources_is_list(self, report: dict) -> None:
+        assert isinstance(report["wikiSources"], list)
+        assert len(report["wikiSources"]) > 0
+
+    def test_wiki_source_entry_fields(self, report: dict) -> None:
+        for entry in report["wikiSources"]:
+            assert isinstance(entry, dict)
+            assert "wikiPath" in entry
+            assert "rawPath" in entry
+            assert "sourceUrl" in entry
+            # wikiPath and rawPath must be non-empty
+            assert isinstance(entry["wikiPath"], str) and len(entry["wikiPath"]) > 0
+            assert isinstance(entry["rawPath"], str) and len(entry["rawPath"]) > 0
+            # sourceUrl is a string (may be empty)
+            assert isinstance(entry["sourceUrl"], str)
+            # wikiPath must start with wiki/
+            assert entry["wikiPath"].startswith("wiki/")
+            # rawPath must be a repo-relative path
+            assert "raw/assets/" in entry["rawPath"]
+
+    def test_wiki_source_wiki_paths_exist(self, report: dict) -> None:
+        for entry in report["wikiSources"]:
+            full_path = REPO_ROOT / entry["wikiPath"]
+            assert full_path.exists(), f"Wiki page not found: {entry['wikiPath']}"
+
+    def test_wiki_source_raw_paths_exist(self, report: dict) -> None:
+        for entry in report["wikiSources"]:
+            full_path = REPO_ROOT / entry["rawPath"]
+            assert full_path.exists(), f"Raw asset not found: {entry['rawPath']}"
+
+
+# ---------------------------------------------------------------------------
+# Rule IDs contract
+# ---------------------------------------------------------------------------
+
+
+class TestRuleIds:
+    """Verify ruleIds[] entries."""
+
+    def test_rule_ids_is_list(self, report: dict) -> None:
+        assert isinstance(report["ruleIds"], list)
+        assert len(report["ruleIds"]) > 0
+
+    def test_rule_id_entry_fields(self, report: dict) -> None:
+        for entry in report["ruleIds"]:
+            assert isinstance(entry, dict)
+            assert "code" in entry
+            assert "sourcePath" in entry
+            assert isinstance(entry["code"], str) and len(entry["code"]) > 0
+            assert isinstance(entry["sourcePath"], str) and len(entry["sourcePath"]) > 0
+            # Code must match the OpenQC <BACKEND>-<FILE_ROLE>-<CATEGORY>-NNN pattern.
+            import re
+
+            assert re.match(
+                r"^QE-INPUT-(ERROR|WARNING|INFO)-\d{3}$", entry["code"]
+            ), f"Rule code {entry['code']} does not match OpenQC rule ID format"
+
+    def test_rule_id_source_paths_exist(self, report: dict) -> None:
+        for entry in report["ruleIds"]:
+            full_path = REPO_ROOT / entry["sourcePath"]
+            assert full_path.exists(), f"Source file not found: {entry['sourcePath']}"
+
+    def test_rule_ids_from_lint_are_present(self, report: dict) -> None:
+        """Verify at least the core lint rules from lint.py are represented."""
+        codes = {r["code"] for r in report["ruleIds"]}
+        expected_core = {
+            "QE-INPUT-ERROR-001",
+            "QE-INPUT-ERROR-002",
+            "QE-INPUT-ERROR-003",
+            "QE-INPUT-WARNING-001",
+            "QE-INPUT-WARNING-002",
+            "QE-INPUT-WARNING-003",
+            "QE-INPUT-ERROR-004",
+            "QE-INPUT-ERROR-005",
+            "QE-INPUT-ERROR-006",
+            "QE-INPUT-ERROR-007",
+            "QE-INPUT-WARNING-004",
+            "QE-INPUT-ERROR-008",
+            "QE-INPUT-ERROR-009",
+            "QE-INPUT-WARNING-010",
+            "QE-INPUT-WARNING-011",
+            "QE-INPUT-WARNING-012",
+            "QE-INPUT-ERROR-013",
+        }
+        missing = expected_core - codes
+        assert not missing, f"Missing expected rule codes: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Source URLs contract
+# ---------------------------------------------------------------------------
+
+
+class TestSourceUrls:
+    """Verify sourceUrls[] entries."""
+
+    def test_source_urls_is_list(self, report: dict) -> None:
+        assert isinstance(report["sourceUrls"], list)
+        assert len(report["sourceUrls"]) > 0
+
+    def test_source_url_entry_fields(self, report: dict) -> None:
+        for entry in report["sourceUrls"]:
+            assert isinstance(entry, dict)
+            assert "rawPath" in entry
+            assert "url" in entry
+            assert isinstance(entry["rawPath"], str)
+            assert isinstance(entry["url"], str) and len(entry["url"]) > 0
+            # URL must start with http:// or https://
+            assert entry["url"].startswith("http")
+
+    def test_source_url_has_upstream_urls(self, report: dict) -> None:
+        """Must include at least the core QE upstream URLs."""
+        all_urls = {e["url"] for e in report["sourceUrls"]}
+        assert any(
+            "quantum-espresso.org" in u for u in all_urls
+        ), "Missing quantum-espresso.org URLs"
+
+
+# ---------------------------------------------------------------------------
+# Raw manifest contract
+# ---------------------------------------------------------------------------
+
+
+class TestRawManifest:
+    """Verify rawManifest entries."""
+
+    def test_raw_manifest_is_object(self, report: dict) -> None:
+        assert isinstance(report["rawManifest"], dict)
+        assert len(report["rawManifest"]) > 0
+
+    def test_raw_manifest_entries_are_valid(self, report: dict) -> None:
+        manifest = report["rawManifest"]
+        assert isinstance(manifest["path"], str) and len(manifest["path"]) > 0
+        assert isinstance(manifest["ok"], bool)
+        assert manifest["path"].startswith("raw/assets/")
+
+    def test_raw_manifest_paths_exist(self, report: dict) -> None:
+        full_path = REPO_ROOT / report["rawManifest"]["path"]
+        assert full_path.exists(), f"Raw manifest not found: {report['rawManifest']['path']}"
+
+    def test_all_raw_assets_ok(self, report: dict) -> None:
+        """No raw asset should be flagged as failing."""
+        assert report["rawManifest"]["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Regeneration smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestRegeneration:
+    """Verify the checker script can regenerate the report."""
+
+    def test_checker_script_exists(self) -> None:
+        assert CHECKER_SCRIPT.exists(), f"Checker script not found: {CHECKER_SCRIPT}"
+
+    def test_checker_script_runs(self) -> None:
+        """Run the checker script and confirm it exits 0."""
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, str(CHECKER_SCRIPT)],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+        assert (
+            result.returncode == 0
+        ), f"Checker script failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        assert REPORT_PATH.exists()
+
+
+# ---------------------------------------------------------------------------
+# Consistency / cross-reference tests
+# ---------------------------------------------------------------------------
+
+
+class TestConsistency:
+    """Cross-reference checks between report sections."""
+
+    def test_rule_ids_at_lint_module(self, report: dict) -> None:
+        """Lint.py should be one of the sources for rule IDs."""
+        lint_sources = [r for r in report["ruleIds"] if "lint.py" in r["sourcePath"]]
+        assert len(lint_sources) > 0, "No rule IDs from lint.py"
+
+    def test_docstring_wiki_paths_in_wiki_sources(self, report: dict) -> None:
+        """Docstring wiki paths should also appear in wikiSources."""
+        docstring_wikis = {e["wikiPath"] for e in report["docstrings"]}
+        wiki_source_wikis = {e["wikiPath"] for e in report["wikiSources"]}
+        # At least some overlap is expected
+        overlap = docstring_wikis & wiki_source_wikis
+        assert len(overlap) > 0, "No wiki path appears in both docstrings and wikiSources"


### PR DESCRIPTION
## Summary

Implements the OpenQC v1 docstring/wiki/raw traceability report for QE LSP.

## Changes

- Adds `scripts/generate-traceability-report.py` to generate `reports/docstring-wiki-raw-traceability.json` with `schemaVersion: openqc.lsp.traceability.v1`.
- Adds `raw/assets/manifest.json` as the canonical raw evidence manifest referenced by `rawManifest.path`.
- Links source docstrings to concrete `wiki/` pages through `See also:` references.
- Normalizes rule IDs to OpenQC format, for example `QE-INPUT-ERROR-001`.
- Adds focused tests for the report schema, docstring/wiki/raw links, rule IDs, source URLs, manifest descriptor, and regeneration.
- Adds a `traceability` Make target without changing the existing `check` target.

## Test Plan

```bash
python3 scripts/generate-traceability-report.py
python3 -m pytest tests/test_openqc_traceability.py -q --no-cov
python3 - <<'PY'
import json,re
from pathlib import Path
data=json.loads(Path('reports/docstring-wiki-raw-traceability.json').read_text())
assert data['schemaVersion']=='openqc.lsp.traceability.v1'
assert data['rawManifest']['path']=='raw/assets/manifest.json'
assert data['rawManifest']['ok'] is True
assert not [r['code'] for r in data['ruleIds'] if not re.match(r'^[A-Z]+-[A-Z]+-[A-Z]+-\\d{3}$', r['code'])]
PY
git diff --check
```

Closes #100
